### PR TITLE
release: conexus 6.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v6.6.0"
+        "ref": "v6.6.1"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "6.6.0"
+      "version": "6.6.1"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v6.6.0"
+        "ref": "v6.6.1"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "6.6.0"
+      "version": "6.6.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.6.1] - 2026-07-11
+
+Bug-fix release. Three service-mode daemon gaps found and fixed same-day
+during live incident triage on a production install, plus a follow-up sweep
+of the same bug class elsewhere in the catalog doctor surface, found by a
+retroactive stacked-reviewer pass (nexus-pyv0e, nexus-64np7, nexus-bikit
+tracks a remaining architectural follow-up, not shipped here).
+
+### Fixed
+
+- `nx daemon t2 ensure-running`: now short-circuits immediately
+  (`SERVICE_MODE_SKIP`) when the memory store is in service mode, instead of
+  cold-spawning a process that exits instantly by design. Every nx-mcp
+  session-start call and `nx upgrade` invoke this path; the missing check
+  could trip the crash-loop guard with a misleading "crash-loop suppressed"
+  error under concurrent sessions even though nothing was actually broken.
+- `nx catalog doctor --name-vs-embed-dim`: fixed a crash
+  (`AttributeError: 'HttpVectorClient' object has no attribute '_client'`) in
+  service/cloud mode — the now-primary T3 backend. Also fixed the same
+  Chroma-internals reach-through in `--t3-vs-catalog` (was silently
+  swallowing the error into a false PASS with zero detection capability),
+  `--chunk-size-distribution`, `--chunk-text-dedup`, and
+  `--t3-doc-id-coverage` (these already failed loud, just non-functional in
+  service mode).
+- Aspect-worker daemon `reclaim_stale` loop: previously held one HTTP client
+  for its entire process lifetime with no recovery on a credential error. A
+  rotated bearer token could cause continuous 401s until a manual daemon
+  restart (an actual incident: 23+ hours, 1394 failures). Now rebuilds the
+  client on demand after any failure, so a token rotation self-heals within
+  one reclaim interval (~30s).
+
 ## [6.6.0] - 2026-07-10
 
 The clean-5.x-upgrade release. Hardens the store-migration path against the

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ uv tool upgrade conexus                  # upgrade the nx CLI — PRESERVES your
 
 When you update the **Claude Code plugin** (`/plugin update`), upgrade the CLI to the matching version at the same time so the two stay in lockstep.
 
+### Something broken?
+
+[nexus-recovery-runbook](https://gist.github.com/Hellblazer/08f0a615e3d73e47d8062bce4829b611) is a
+diagnose-first recovery procedure meant to be handed to a Claude Code session as its first message —
+the assistant runs it phase by phase, pausing for your explicit go-ahead before anything that upgrades
+or migrates data, and gathers redacted forensics + opens a GitHub issue (or emails a fallback address)
+if it can't resolve things itself. It's a convenience for a broken install, not a substitute for filing
+an issue directly if something looks wrong — and it carries its own guardrails (read-only diagnosis
+first, no destructive commands without confirmation, no secrets ever leave the machine), but you're
+trusting an LLM to run real commands against your install. Review what it does before handing it off,
+especially the first time.
+
 ## Going deeper
 
 | If you want to... | Read |

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the conexus plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.6.1] - 2026-07-11
+
+- Plugin version aligned with conexus 6.6.1 (bug-fix release: T2 `ensure-running` service-mode crash-loop fix, `nx catalog doctor` service-mode crash sweep across five checks, aspect-worker credential-rotation self-heal). No plugin-side changes.
+
 ## [6.6.0] - 2026-07-10
 
 - Plugin version aligned with conexus 6.6.0 (clean-5.x-upgrade release: `nx migration-audit`, `nx doctor` chash-conformance probe, GH #1390 legacy-id migration guard + install-binary poison gate, T3 local-model-pin fix, engine pin advanced to v0.1.37). No plugin-side changes.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1731,6 +1731,17 @@ named config_dir, otherwise spawns it in the background (detached
 subprocess) and polls the discovery file until reachable (or the
 timeout expires).
 
+Service mode (RDR-176; nexus-daemon-6.6.1-service-mode-skip): when the
+memory store is in SERVICE mode, the SQLite T2 tier is a frozen
+migration source and the Java service is the live substrate — no
+client ever connects to a local T2 daemon. `ensure-running` detects
+this up front and returns immediately (`SERVICE_MODE_SKIP`, exit 0)
+without attempting a spawn. Prior to 6.6.1 this check was missing:
+every session-start call cold-spawned a process that exited instantly
+by design, and repeated calls across concurrent MCP sessions could
+trip the crash-loop guard below with a misleading
+"crash-loop suppressed" error even though nothing was actually broken.
+
 Stale discovery files left behind by crashed daemons trigger a
 fresh spawn rather than a false-positive — the probe is
 `os.kill(pid, 0)` against the discovery-file PID.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "6.6.0"
+version = "6.6.1"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=6.6.0",
+    "conexus[local]>=6.6.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "6.6.0"
+version = "6.6.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/commands/catalog_cmds/doctor.py
+++ b/src/nexus/commands/catalog_cmds/doctor.py
@@ -664,7 +664,7 @@ def _run_chunk_size_distribution() -> dict:
     tables: dict[str, dict] = {}
     for name in collections:
         try:
-            col = t3._client.get_collection(name=name)
+            col = t3.get_collection(name=name)
         except Exception as exc:  # noqa: BLE001 — best-effort fallback path; failure is non-fatal here
             tables[name] = {"error": f"open: {exc}"}
             overall_pass = False
@@ -780,7 +780,7 @@ def _run_chunk_text_dedup() -> dict:
     chash_to_collections: dict[str, set[str]] = {}
     for name in collections:
         try:
-            col = t3._client.get_collection(name=name)
+            col = t3.get_collection(name=name)
         except Exception as exc:  # noqa: BLE001 — best-effort fallback path; failure is non-fatal here
             within_summary[name] = {"error": f"open: {exc}"}
             overall_pass = False
@@ -912,10 +912,16 @@ def _run_t3_vs_catalog() -> dict:
         # Only flag if the T3 collection actually has chunks; an empty
         # T3 collection with no docs is the zombie class below.
         try:
-            col = t3_db._client.get_collection(name=name)
+            col = t3_db.get_collection(name=name)
             count = col.count()
-        except Exception:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
-            count = 0
+        except Exception as exc:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
+            # nexus-pyv0e sibling: this used to reach into t3_db._client
+            # (Chroma-only), which raised AttributeError in service mode
+            # and got silently swallowed here into count=0 — a false PASS
+            # with zero detection capability, not a loud error. Record the
+            # failure instead of pretending the collection is empty.
+            t3_orphans.append({"name": name, "error": str(exc)})
+            continue
         if count > 0:
             t3_orphans.append({"name": name, "chunk_count": count})
 
@@ -925,11 +931,16 @@ def _run_t3_vs_catalog() -> dict:
         r["name"] for r in projection if not r.get("superseded_by")
     }
     zombies = []
+    zombie_errors: list[dict] = []
     for name in sorted(projection_names & t3_names):
         try:
-            col = t3_db._client.get_collection(name=name)
+            col = t3_db.get_collection(name=name)
             count = col.count()
-        except Exception:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
+        except Exception as exc:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
+            # nexus-pyv0e sibling: `continue`-past-error here previously
+            # meant a failed check for a candidate zombie silently dropped
+            # it from consideration — a false PASS, not a loud error.
+            zombie_errors.append({"name": name, "error": str(exc)})
             continue
         if count == 0:
             zombies.append(name)
@@ -943,11 +954,13 @@ def _run_t3_vs_catalog() -> dict:
 
     overall_pass = (
         not t3_orphans and not zombies and not docs_missing
+        and not zombie_errors
     )
     return {
         "pass": overall_pass,
         "t3_orphans": t3_orphans,
         "zombies": zombies,
+        "zombie_errors": zombie_errors,
         "docs_pointing_at_missing_t3": docs_missing,
     }
 
@@ -964,7 +977,10 @@ def _print_t3_vs_catalog_text(report: dict) -> None:
             f"({len(report['t3_orphans'])}):"
         )
         for o in report["t3_orphans"][:20]:
-            click.echo(f"    {o['name']}  chunks={o['chunk_count']}")
+            if "error" in o:
+                click.echo(f"    {o['name']}  ERROR: {o['error']}")
+            else:
+                click.echo(f"    {o['name']}  chunks={o['chunk_count']}")
     if report["zombies"]:
         click.echo(
             f"  Zombie collections (registered, 0 chunks in T3) "
@@ -975,6 +991,13 @@ def _print_t3_vs_catalog_text(report: dict) -> None:
         click.echo(
             "  Remediate: nx catalog collection-gc --apply"
         )
+    if report.get("zombie_errors"):
+        click.echo(
+            f"  Collections that could not be checked for zombie status "
+            f"({len(report['zombie_errors'])}):"
+        )
+        for e in report["zombie_errors"][:20]:
+            click.echo(f"    {e['name']}  ERROR: {e['error']}")
     if report["docs_pointing_at_missing_t3"]:
         click.echo(
             f"  Catalog documents whose physical_collection is gone "
@@ -1634,7 +1657,7 @@ def _run_t3_doc_id_coverage(
             continue
         _tc = _time.monotonic()
         try:
-            col = t3._client.get_collection(name=coll_name)
+            col = t3.get_collection(name=coll_name)
         except Exception as exc:  # noqa: BLE001 — best-effort fallback path; failure is non-fatal here
             per_coll[coll_name] = {
                 "error": f"open: {exc}",

--- a/src/nexus/commands/catalog_cmds/doctor.py
+++ b/src/nexus/commands/catalog_cmds/doctor.py
@@ -1055,7 +1055,6 @@ def _run_name_vs_embed_dim() -> dict:
             "error": f"Failed to list T3 collections: {exc}",
         }
 
-    client = t3_db._client  # type: ignore[attr-defined]
     for name in cols:
         if not is_conformant_collection_name(name):
             skipped_non_conformant += 1
@@ -1067,14 +1066,22 @@ def _run_name_vs_embed_dim() -> dict:
             unknown_token.append({"collection": name, "token": token})
             continue
         try:
-            coll = client.get_collection(name)
-            sample = coll.get(limit=1, include=["embeddings"])
+            # nexus-pyv0e: sample via the dual-mode-safe public surface
+            # (get_collection + get_embeddings), not client._client — the
+            # service-mode HttpVectorClient has no ._client attribute, only
+            # local T3Database's raw chromadb client does.
+            coll = t3_db.get_collection(name)
+            sample = coll.get(limit=1)
+            ids = sample.get("ids") or []
+            if not ids:
+                empty.append(name)
+                continue
+            embs = t3_db.get_embeddings(name, ids[:1])
         except Exception as exc:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
             unknown_token.append(
                 {"collection": name, "token": token, "error": str(exc)}
             )
             continue
-        embs = sample.get("embeddings")
         if embs is None or len(embs) == 0:
             empty.append(name)
             continue

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1071,6 +1071,7 @@ class T2EnsureOutcome(Enum):
     DEFERRED_SIGTERM = "deferred_sigterm"        # stale daemon ALIVE; SIGTERM'd but did not exit in window
     CRASHLOOP_SUPPRESSED = "crashloop_suppressed"  # no live incumbent daemon (never existed, or was fully reaped); crash-loop guard refused respawn
     SPAWN_FAILED = "spawn_failed"                # no daemon: cold-spawned process died or never became reachable
+    SERVICE_MODE_SKIP = "service_mode_skip"      # memory store is in SERVICE mode; the SQLite daemon has no role (RDR-176)
 
 
 def _t2_ensure_running_inner(
@@ -1087,6 +1088,27 @@ def _t2_ensure_running_inner(
     import time as _time  # noqa: PLC0415 — deferred import — CLI startup cost, only needed in this subcommand path
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+
+    # RDR-176 Phase 1 (Gap 2): in SERVICE mode the SQLite T2 tier is a frozen
+    # migration source and the Java service is the live substrate — no client
+    # ever connects to this daemon (``run_t2_daemon`` already no-ops for the
+    # same reason). Without this check every caller (nx-mcp's first-run hook,
+    # ``nx upgrade``) cold-spawns a process that exits immediately by design,
+    # and repeated calls across concurrent MCP sessions trip the crash-loop
+    # guard below with a misleading "crash-loop suppressed" error even though
+    # nothing is actually broken (nexus-daemon-6.6.0-service-mode-skip).
+    from nexus.db.storage_mode import (  # noqa: PLC0415 — deferred import — CLI startup cost, only needed in this subcommand path
+        StorageBackend,
+        storage_backend_for,
+    )
+
+    if storage_backend_for("memory") == StorageBackend.SERVICE:
+        if not quiet:
+            click.echo(
+                "T2 daemon not needed: memory store is in service mode "
+                "(Java service is the live substrate)."
+            )
+        return T2EnsureOutcome.SERVICE_MODE_SKIP
 
     def _running_daemon() -> tuple[int, str] | None:
         """Return (pid, daemon_version) of the live daemon, or None.

--- a/src/nexus/daemon/aspect_worker_daemon.py
+++ b/src/nexus/daemon/aspect_worker_daemon.py
@@ -226,10 +226,32 @@ class AspectWorkerDaemon:
         """One reclaim sweep (the loop body; also the main-thread test seam).
         Emits a structured signal when rows are reset (RDR-173 P5 observability,
         nexus-xv5fl) so self-healing is observable, and logs a failure without
-        killing the loop."""
+        killing the loop.
+
+        nexus-64np7: rebuilds ``self._reclaim_queue`` on demand (here, not
+        just once at a failure site) so a rotated/expired credential baked
+        into the handle at construction time self-heals within one interval
+        instead of retrying the same broken client forever — this daemon is
+        long-lived and previously held ONE handle for its whole lifetime,
+        unlike the claim_batch path (mcp_infra._service_t2_write_locked)
+        which already evicts-and-rebuilds on any exception. The
+        2026-07-10 incident (401 every 30s for 23+ hours) had no recovery
+        short of a manual daemon restart before this fix. Retrying the
+        rebuild every call (rather than once at eviction time) also covers
+        a rebuild that itself transiently fails (e.g. the service is briefly
+        unreachable) — it gets another chance next interval instead of
+        going permanently silent.
+        """
+        if self._reclaim_queue is None:
+            try:
+                self._reclaim_queue = self._queue_factory()
+            except Exception as rebuild_exc:  # noqa: BLE001 - rebuild is best-effort; next interval retries
+                _log.warning(
+                    "aspect_worker_daemon.reclaim_queue_rebuild_failed",
+                    tenant=self._tenant, error=str(rebuild_exc),
+                )
+                return
         queue = self._reclaim_queue
-        if queue is None:
-            return
         try:
             n = queue.reclaim_stale(self._stale_timeout)
             if n:
@@ -242,6 +264,14 @@ class AspectWorkerDaemon:
                 "aspect_worker_daemon.reclaim_failed",
                 tenant=self._tenant, error=str(exc),
             )
+            self._reclaim_queue = None
+            try:
+                queue.close()
+            except Exception as close_exc:  # noqa: BLE001 - best-effort teardown of an already-broken client
+                _log.warning(
+                    "aspect_worker_daemon.reclaim_queue_close_failed",
+                    tenant=self._tenant, error=str(close_exc),
+                )
 
     def heartbeat_once(self) -> None:
         """Run a single heartbeat tick (test seam + the loop body)."""

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -323,6 +323,14 @@ def _reassert_t2_daemon() -> bool:
             "t2_index_write_version_skew_spawn_failed",
             "daemon spawn failed; the direct write below is safe (no live daemon)",
         ),
+        T2EnsureOutcome.SERVICE_MODE_SKIP: (
+            "t2_index_write_version_skew_service_mode_skip",
+            "memory store is in SERVICE mode (RDR-176); the SQLite daemon has no "
+            "role here — this path should not normally be reached (t2_index_write "
+            "already short-circuits to the service-backed writer before ever "
+            "constructing a T2Client), but the direct write below is safe "
+            "regardless (no live SQLite daemon to double-write against)",
+        ),
     }
     event, hint = events.get(
         outcome,

--- a/tests/daemon/test_aspect_worker_reclaim.py
+++ b/tests/daemon/test_aspect_worker_reclaim.py
@@ -163,3 +163,52 @@ def test_reclaim_failure_does_not_kill_the_loop(tmp_path: Path) -> None:
         assert len(q.reclaim_calls) >= 2   # survived the first failure, ticked again
     finally:
         d.stop()
+
+
+def test_reclaim_failure_evicts_and_rebuilds_queue(tmp_path: Path) -> None:
+    """nexus-64np7: a reclaim failure must evict the stale queue handle and
+    rebuild via queue_factory, so the NEXT sweep re-resolves credentials
+    instead of retrying the same broken client forever. Root cause of a
+    2026-07-10 incident: a rotated bearer token produced a 401 on
+    reclaim_stale every ~30s for 23+ hours with no recovery short of a
+    manual daemon restart, because this handle (unlike claim_batch's,
+    which already evicts via mcp_infra._service_t2_write_locked) was held
+    for the daemon's entire lifetime with no eviction on error."""
+
+    class _OnceFailingQueue(_FakeQueue):
+        def __init__(self, fail: bool) -> None:
+            super().__init__()
+            self._fail = fail
+
+        def reclaim_stale(self, timeout_seconds: int = 300) -> int:
+            self.reclaim_calls.append(timeout_seconds)
+            if self._fail:
+                raise RuntimeError("401 Unauthorized (stale token)")
+            return 0
+
+    created: list[_OnceFailingQueue] = []
+
+    def factory() -> _OnceFailingQueue:
+        q = _OnceFailingQueue(fail=(len(created) == 0))
+        created.append(q)
+        return q
+
+    d = AspectWorkerDaemon(
+        config_dir=tmp_path, tenant="default",
+        worker_factory=_FakeWorker, queue_factory=factory,
+        reclaim_interval=0.03, stale_timeout_seconds=60,
+    )
+    d.start()
+    try:
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and len(created) < 2:
+            time.sleep(0.02)
+        assert len(created) >= 2, "stale queue was never rebuilt after the failure"
+        assert created[0].reclaim_calls == [60]
+        assert created[0].closed == 1          # the stale (failed) handle was released
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not created[1].reclaim_calls:
+            time.sleep(0.02)
+        assert created[1].reclaim_calls, "the rebuilt handle never got a chance to reclaim"
+    finally:
+        d.stop()

--- a/tests/daemon/test_t2_daemon_observability.py
+++ b/tests/daemon/test_t2_daemon_observability.py
@@ -27,6 +27,7 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from nexus.cli import main
@@ -400,6 +401,35 @@ class TestCrashLoopRespawnRefusal:
             )
         assert spawns == []
         assert len(errors) == 1, f"must log once across invocations, saw {errors}"
+
+
+class TestEnsureRunningServiceModeSkipCli:
+    """nexus-daemon-6.6.0-service-mode-skip / critic finding on PR #1392:
+    the earlier tests only asserted ``_t2_ensure_running_inner``'s return
+    value directly. Drive the actual Click command so a future change to
+    ``t2_ensure_running_cmd``'s exit-code mapping (e.g. converting the
+    allowlist tuple to an exhaustive-style construct) has a test that
+    would catch SERVICE_MODE_SKIP landing in the failure branch."""
+
+    def test_service_mode_skip_exits_zero_through_cli(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.db import storage_mode
+
+        monkeypatch.setattr(
+            storage_mode, "storage_backend_for",
+            lambda store: storage_mode.StorageBackend.SERVICE,
+        )
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail("must not spawn in service mode"),
+        )
+
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "ensure-running",
+                   "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
 
 
 class _Unreachable:

--- a/tests/daemon/test_t2_ensure_running_inner.py
+++ b/tests/daemon/test_t2_ensure_running_inner.py
@@ -122,6 +122,45 @@ class TestInnerReachable:
         assert outcome == T2EnsureOutcome.REACHABLE
 
 
+class TestInnerServiceModeSkip:
+    """RDR-176 Phase 1 (Gap 2): memory store in SERVICE mode -> no spawn."""
+
+    def test_service_mode_skips_without_spawning(self, tmp_path, monkeypatch) -> None:
+        from nexus.db import storage_mode
+
+        monkeypatch.setattr(
+            storage_mode, "storage_backend_for",
+            lambda store: storage_mode.StorageBackend.SERVICE,
+        )
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail("must not spawn in service mode"),
+        )
+        outcome = _t2_ensure_running_inner(str(tmp_path), timeout=5.0, quiet=True)
+        assert outcome == T2EnsureOutcome.SERVICE_MODE_SKIP
+
+    def test_service_mode_skip_does_not_touch_crashloop_counter(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """A repeated skip must never accumulate toward the crash-loop guard —
+        that guard exists for genuine spawn failures, not a mode where no
+        spawn is ever attempted."""
+        from nexus.db import storage_mode
+
+        monkeypatch.setattr(
+            storage_mode, "storage_backend_for",
+            lambda store: storage_mode.StorageBackend.SERVICE,
+        )
+        import time as _t
+
+        import nexus.commands.daemon as _daemon
+
+        for _ in range(10):
+            outcome = _t2_ensure_running_inner(str(tmp_path), timeout=5.0, quiet=True)
+            assert outcome == T2EnsureOutcome.SERVICE_MODE_SKIP
+        assert not _daemon._crashloop_tripped(tmp_path, now=_t.time())
+
+
 # ---------------------------------------------------------------------------
 # DEFERRED_WRITE_LOCK path: stale daemon alive, WAL write-lock held
 # ---------------------------------------------------------------------------

--- a/tests/test_catalog_doctor_name_vs_embed_dim.py
+++ b/tests/test_catalog_doctor_name_vs_embed_dim.py
@@ -281,3 +281,85 @@ class TestNameVsEmbedDim:
         assert "name-vs-embed-dim: FAIL" in result.output
         assert name in result.output
         assert "rename" in result.output.lower()
+
+
+class TestNameVsEmbedDimRealHttpVectorClient:
+    """nexus-umvh2 doctrine (Wave-review CRITICAL, critic finding on
+    nexus-pyv0e): a hand-rolled duck-typed fake proves the fake's shape
+    doesn't crash, not that the REAL HttpVectorClient's actual
+    get_collection/get_embeddings work through the real doctor command in
+    service mode. Construct the real client; fake only the HTTP transport
+    (``_post``/``_get``) — a missing/renamed method on HttpVectorClient
+    fails HARD here instead of being absorbed by a duck-typed double.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_client(self):
+        from nexus.db.http_vector_client import reset_http_vector_client_for_tests
+        reset_http_vector_client_for_tests()
+        yield
+        reset_http_vector_client_for_tests()
+
+    def test_real_client_pass_when_dim_matches(
+        self, runner, monkeypatch: pytest.MonkeyPatch,
+    ):
+        from nexus.db.http_vector_client import HttpVectorClient
+
+        name = "code__nexus-1-1__voyage-code-3__v1"
+
+        def fake_get(path, **kw):
+            assert path == "/v1/vectors/stats"
+            return [{"name": name, "dim": 1024, "count": 1}]
+
+        def fake_post(path, body, **kw):
+            if path == "/v1/vectors/get":
+                assert body["collection"] == name
+                return {"ids": ["c1"], "documents": ["x"], "metadatas": [{}]}
+            if path == "/v1/vectors/get-embeddings":
+                assert body == {"collection": name, "ids": ["c1"]}
+                return {"embeddings": [[0.1] * 1024]}
+            raise AssertionError(f"unexpected path {path}")
+
+        monkeypatch.setattr("nexus.db.http_vector_client._get", fake_get)
+        monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+        monkeypatch.setattr("nexus.db.make_t3", lambda: HttpVectorClient())
+
+        result = runner.invoke(doctor_cmd, ["--name-vs-embed-dim", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is True
+        assert payload["checked"] == 1
+        assert payload["mismatches"] == []
+
+    def test_real_client_fail_when_dim_mismatches(
+        self, runner, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """The 4.28-era bug shape, reproduced through the REAL
+        HttpVectorClient: name claims voyage-code-3 (1024d) but the
+        service actually holds 384-dim vectors."""
+        from nexus.db.http_vector_client import HttpVectorClient
+
+        name = "code__nexus-1-1__voyage-code-3__v1"
+
+        def fake_get(path, **kw):
+            return [{"name": name, "dim": 384, "count": 1}]
+
+        def fake_post(path, body, **kw):
+            if path == "/v1/vectors/get":
+                return {"ids": ["c1"], "documents": ["x"], "metadatas": [{}]}
+            if path == "/v1/vectors/get-embeddings":
+                return {"embeddings": [[0.1] * 384]}
+            raise AssertionError(f"unexpected path {path}")
+
+        monkeypatch.setattr("nexus.db.http_vector_client._get", fake_get)
+        monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+        monkeypatch.setattr("nexus.db.make_t3", lambda: HttpVectorClient())
+
+        result = runner.invoke(doctor_cmd, ["--name-vs-embed-dim", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is False
+        m = payload["mismatches"][0]
+        assert m["collection"] == name
+        assert m["expected_dim"] == 1024
+        assert m["actual_dim"] == 384

--- a/tests/test_catalog_doctor_name_vs_embed_dim.py
+++ b/tests/test_catalog_doctor_name_vs_embed_dim.py
@@ -62,7 +62,43 @@ def _fake_t3(client, names: list[str]):
 
         def list_collections(self):
             return [{"name": n} for n in names]
+
+        def get_collection(self, name):
+            return client.get_collection(name)
+
+        def get_embeddings(self, collection_name, ids):
+            import numpy as np
+            col = client.get_collection(collection_name)
+            result = col.get(ids=ids, include=["embeddings"])
+            by_id = dict(zip(result["ids"], result["embeddings"]))
+            return np.array(
+                [by_id[i] for i in ids if i in by_id], dtype=np.float32,
+            )
     return _FakeT3()
+
+
+def _fake_t3_service_like(client, names: list[str]):
+    """Simulates HttpVectorClient's public surface only — no ``_client``
+    attribute. Regression guard for nexus-pyv0e: the doctor check must not
+    reach into Chroma internals, only the dual-mode-safe public methods
+    (``get_collection`` / ``get_embeddings``) both T3Database and
+    HttpVectorClient expose."""
+    class _FakeServiceT3:
+        def list_collections(self):
+            return [{"name": n} for n in names]
+
+        def get_collection(self, name):
+            return client.get_collection(name)
+
+        def get_embeddings(self, collection_name, ids):
+            import numpy as np
+            col = client.get_collection(collection_name)
+            result = col.get(ids=ids, include=["embeddings"])
+            by_id = dict(zip(result["ids"], result["embeddings"]))
+            return np.array(
+                [by_id[i] for i in ids if i in by_id], dtype=np.float32,
+            )
+    return _FakeServiceT3()
 
 
 class TestNameVsEmbedDim:
@@ -183,6 +219,50 @@ class TestNameVsEmbedDim:
         assert payload["pass"] is True
         assert payload["checked"] == 0
         assert name in payload["empty"]
+
+    def test_service_mode_no_client_attribute_does_not_crash(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Regression (nexus-pyv0e): HttpVectorClient has no ``_client``
+        attribute — reaching into it raised an unhandled AttributeError in
+        service/cloud mode. A T3 handle exposing only the public
+        get_collection/get_embeddings surface must work identically."""
+        name = "code__myproj__minilm-l6-v2-384__v1"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3",
+            lambda: _fake_t3_service_like(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is True
+        assert payload["mismatches"] == []
+        assert payload["checked"] == 1
+
+    def test_service_mode_mismatch_still_detected(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Same mismatch-detection guarantee holds on the service-like
+        (no ``_client``) path, not just the local-Chroma path."""
+        name = "code__myproj__voyage-code-3__v1"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3",
+            lambda: _fake_t3_service_like(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is False
+        m = payload["mismatches"][0]
+        assert m["collection"] == name
+        assert m["expected_dim"] == 1024
+        assert m["actual_dim"] == 384
 
     def test_text_output_includes_remediation_hint(
         self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_catalog_doctor_new_checks.py
+++ b/tests/test_catalog_doctor_new_checks.py
@@ -105,6 +105,9 @@ class TestChunkSizeDistribution:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "code__ok"}]
 
@@ -139,6 +142,9 @@ class TestChunkSizeDistribution:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "code__micros"}]
 
@@ -171,6 +177,9 @@ class TestChunkSizeDistribution:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "code__big"}]
 
@@ -199,6 +208,9 @@ class TestChunkSizeDistribution:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "taxonomy__centroids"}]
 
@@ -226,6 +238,9 @@ class TestChunkTextDedup:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
             def list_collections(self):
                 return [{"name": "code__cleanup"}]
@@ -260,6 +275,9 @@ class TestChunkTextDedup:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "code__bug"}]
 
@@ -291,6 +309,9 @@ class TestChunkTextDedup:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
             def list_collections(self):
                 return [{"name": "code__a"}, {"name": "code__b"}]
@@ -335,6 +356,9 @@ class TestT3VsCatalog:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "docs__clean"}]
 
@@ -365,6 +389,9 @@ class TestT3VsCatalog:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
             def list_collections(self):
                 return [{"name": "code__orphan"}]
@@ -401,6 +428,9 @@ class TestT3VsCatalog:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
             def list_collections(self):
                 return []  # no T3 collections at all

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -113,6 +113,9 @@ class TestCoveragePasses:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
@@ -138,6 +141,9 @@ class TestCoveragePasses:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -169,6 +175,9 @@ class TestCoverageFails:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
@@ -194,6 +203,9 @@ class TestCoverageFails:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -228,6 +240,9 @@ class TestCoverageFails:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -268,6 +283,9 @@ class TestCombined:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -334,6 +352,9 @@ class TestOrphanRatioSurface:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
 
         # Text output assertions
@@ -403,6 +424,9 @@ class TestOrphanRatioSurface:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
 
         text_result = runner.invoke(doctor_cmd, ["--t3-doc-id-coverage"])
@@ -431,6 +455,9 @@ class TestOrphanRatioSurface:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
 
         json_result = runner.invoke(
@@ -498,6 +525,9 @@ class TestPhase3ManifestFallback:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
 
         result = runner.invoke(
@@ -547,6 +577,9 @@ class TestBypassSchemaSkipped:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -598,6 +631,9 @@ class TestSupersededSkip:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(

--- a/tests/test_rdr141_version_skew_double_writer.py
+++ b/tests/test_rdr141_version_skew_double_writer.py
@@ -206,6 +206,7 @@ def test_reassert_reachable_returns_true_without_warning(monkeypatch) -> None:
         ("DEFERRED_SIGTERM", "t2_index_write_version_skew_cycle_deferred_sigterm"),
         ("CRASHLOOP_SUPPRESSED", "t2_index_write_version_skew_crashloop_down"),
         ("SPAWN_FAILED", "t2_index_write_version_skew_spawn_failed"),
+        ("SERVICE_MODE_SKIP", "t2_index_write_version_skew_service_mode_skip"),
     ],
 )
 def test_reassert_nonreachable_returns_false_with_distinct_event(
@@ -312,6 +313,7 @@ def test_all_nonreachable_outcomes_have_a_distinct_event() -> None:
         T2EnsureOutcome.DEFERRED_SIGTERM,
         T2EnsureOutcome.CRASHLOOP_SUPPRESSED,
         T2EnsureOutcome.SPAWN_FAILED,
+        T2EnsureOutcome.SERVICE_MODE_SKIP,
     }
     non_reachable = set(T2EnsureOutcome) - {T2EnsureOutcome.REACHABLE}
     assert non_reachable == mapped, (

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "6.6.0"
+version = "6.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Bug-fix release. All manifests bumped in lock-step (`pyproject.toml`, `marketplace.json` version + `source.ref` fields, `conexus/`+`sn/` `plugin.json`, `mcpb/pyproject.toml` including the `conexus[local]` dependency pin, `mcpb/manifest.json`). `uv.lock` refreshed.

### Fixes shipped (from PR #1392 + #1394, live-incident triage on a production install)

- **T2 `ensure-running`** now short-circuits (`SERVICE_MODE_SKIP`) in service mode instead of cold-spawning a process that exits instantly and can trip the crash-loop guard with a misleading error.
- **`nx catalog doctor`** service-mode crash sweep across 5 checks (`--name-vs-embed-dim`, `--t3-vs-catalog`, `--chunk-size-distribution`, `--chunk-text-dedup`, `--t3-doc-id-coverage`) — was reaching into Chroma-internals (`t3_db._client`), which crashes or silently false-passes on `HttpVectorClient` (the now-primary T3 backend).
- **Aspect-worker `reclaim_stale`** now rebuilds its HTTP client on demand instead of holding one credential-bearing client for its entire process lifetime — root cause of a real 23+ hour, 1394-failure incident from a rotated bearer token.

See `CHANGELOG.md` for full detail.

### Docs

- `docs/cli-reference.md`: documented the previously-undocumented `SERVICE_MODE_SKIP` behavior.
- `README.md`: new "Something broken?" section pointing at the [nexus-recovery-runbook gist](https://gist.github.com/Hellblazer/08f0a615e3d73e47d8062bce4829b611) — a diagnose-first recovery procedure meant to be handed to a Claude Code session, with its own guardrails (read-only first, pause for confirmation before mutations, redact-before-report). Gist itself updated to reflect the nexus-pyv0e fix landing in this release.

## Test plan

- [x] Engine-freshness gate: `uv run python scripts/check_engine_release_floor.py` — cloud engine v0.1.37, floor v0.1.34, current
- [x] Unit suite: `uv run pytest tests/ -q` — 12721 passed, 0 failed (2 pre-existing local-environment-only failures deselected — stale Chroma Cloud credentials on this dev machine, unrelated to this diff, confirmed clean on CI)
- [x] Integration suite: `uv run pytest -m integration -q` — 74 passed, 0 failed
- [x] `./tests/e2e/release-sandbox.sh smoke` — clean (one script-tolerated, pre-existing `nx catalog setup` gap in a fresh service-mode sandbox with no service running — explicitly `|| true` in the script, all downstream `nx doctor` checks pass)
- [x] All 7 version references verified consistent (no stale 6.6.0 remaining)

## Not included

Do not tag/push `v6.6.1` — per project policy the releaser is human. This PR is prep only.