### PR TITLE
feat(index): refuse nx index repo on a directory with no .git

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -393,6 +393,20 @@ def index_repo_cmd(
     reg = _registry()
     path = path.resolve()
 
+    # nexus-git-guard: refuse a PATH with no .git (file or directory — a
+    # worktree's .git is a file). Without this, indexing the PARENT of many
+    # repos (e.g. ~/git instead of ~/git/myrepo) silently succeeds: git
+    # rev-parse fails, _resolve_main_repo falls back to using the path
+    # as-is, and a bogus owner named after the parent directory (e.g.
+    # "git") gets registered, sweeping in whatever unrelated content lives
+    # underneath it. Real incident 2026-07-10.
+    if not (path / ".git").exists():
+        raise click.ClickException(
+            f"{path} has no .git — this does not look like a repository "
+            "root. If you meant to index a specific repo, pass its path "
+            "directly (e.g. ~/git/myrepo, not ~/git)."
+        )
+
     from nexus.repo_identity import _repo_identity  # noqa: PLC0415 — deliberate function-local import (matches existing deferred-import convention in this function)
     from nexus.logging_setup import open_run_log  # noqa: PLC0415 — deliberate function-local import (matches existing deferred-import convention in this function)
     _log_basename, _log_hash8 = _repo_identity(path)

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -33,6 +33,7 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def repo_dir(home: Path) -> Path:
     d = home / "myrepo"
     d.mkdir()
+    (d / ".git").mkdir()
     return d
 
 
@@ -94,6 +95,34 @@ def test_index_repo_idempotent_when_already_registered(runner, repo_dir, mock_re
 def test_index_repo_invalid_path(runner, home):
     result = runner.invoke(main, ["index", "repo", str(home / "nonexistent")])
     assert result.exit_code != 0
+
+
+def test_index_repo_refuses_directory_without_git(runner, home):
+    """Indexing a directory with no ``.git`` (e.g. the parent of many repos,
+    ``~/git`` instead of ``~/git/myrepo``) must refuse loudly instead of
+    silently registering an owner spanning unrelated content. Real incident
+    2026-07-10: `nx index repo ~/git` created a bogus owner named "git"
+    sweeping in an unrelated project's files."""
+    not_a_repo = home / "git"
+    not_a_repo.mkdir()
+    (not_a_repo / "some_unrelated_project").mkdir()
+    result = runner.invoke(main, ["index", "repo", str(not_a_repo)])
+    assert result.exit_code != 0
+    assert ".git" in result.output
+
+
+def test_index_repo_accepts_git_worktree(runner, home):
+    """A git worktree's ``.git`` is a FILE (containing ``gitdir: ...``), not
+    a directory — the guard must accept that shape too, not just a real
+    ``.git/`` directory."""
+    worktree = home / "myrepo-worktree"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: /somewhere/else/.git/worktrees/myrepo-worktree\n")
+    reg = MagicMock()
+    reg.get.return_value = None
+    result, mock_idx = _invoke_repo(runner, [str(worktree)], reg)
+    assert result.exit_code == 0, result.output
+    mock_idx.assert_called_once()
 
 
 # ── nx index pdf / md basic ──────────────────────────────────────────────────
@@ -221,6 +250,7 @@ def test_monitor_flag_accepted(runner, home, subcmd, extra_args):
     if subcmd == "repo":
         target = home / "myrepo"
         target.mkdir()
+        (target / ".git").mkdir()
     elif subcmd in ("pdf", "md"):
         target = home / f"doc.{subcmd}"
         target.write_bytes(b"fake")

--- a/tests/test_index_lock.py
+++ b/tests/test_index_lock.py
@@ -344,6 +344,7 @@ def test_cli_on_locked_default_is_wait(runner: CliRunner, lock_home: Path) -> No
     """nx index repo uses on_locked='wait' by default."""
     repo = lock_home / "myrepo"
     repo.mkdir()
+    (repo / ".git").mkdir()
 
     mock_reg = MagicMock()
     mock_reg.get.return_value = {"collection": "code__myrepo"}
@@ -362,6 +363,7 @@ def test_cli_on_locked_skip(runner: CliRunner, lock_home: Path) -> None:
     """nx index repo --on-locked=skip passes on_locked='skip'."""
     repo = lock_home / "myrepo"
     repo.mkdir()
+    (repo / ".git").mkdir()
 
     mock_reg = MagicMock()
     mock_reg.get.return_value = {"collection": "code__myrepo"}
@@ -380,6 +382,7 @@ def test_cli_on_locked_invalid_value(runner: CliRunner, lock_home: Path) -> None
     """nx index repo --on-locked=bad rejects invalid values."""
     repo = lock_home / "myrepo"
     repo.mkdir()
+    (repo / ".git").mkdir()
 
     with patch("nexus.commands.index._registry", return_value=MagicMock()):
         result = runner.invoke(main, ["index", "repo", str(repo), "--on-locked=bad"])

--- a/tests/test_index_reminder.py
+++ b/tests/test_index_reminder.py
@@ -24,6 +24,7 @@ def _make_repo(base: Path) -> Path:
     """Create a minimal fake repo directory and return it."""
     repo = base / "myrepo"
     repo.mkdir()
+    (repo / ".git").mkdir()
     return repo
 
 

--- a/tests/test_index_taxonomy.py
+++ b/tests/test_index_taxonomy.py
@@ -12,6 +12,7 @@ from nexus.commands.index import index, _discover_taxonomy
 
 def test_index_repo_triggers_taxonomy_discover(tmp_path) -> None:
     """index_repo_cmd calls _discover_taxonomy after indexing."""
+    (tmp_path / ".git").mkdir()
     calls: list[str] = []
 
     def fake_discover(collection_name, taxonomy, chroma_client, *, force=False):
@@ -39,6 +40,7 @@ def test_index_repo_triggers_taxonomy_discover(tmp_path) -> None:
 
 def test_index_repo_no_taxonomy_flag(tmp_path) -> None:
     """--no-taxonomy skips taxonomy discover."""
+    (tmp_path / ".git").mkdir()
     calls: list[str] = []
 
     def fake_discover(collection_name, taxonomy, chroma_client, *, force=False):
@@ -60,6 +62,7 @@ def test_index_repo_no_taxonomy_flag(tmp_path) -> None:
 
 def test_index_repo_frecency_only_skips_taxonomy(tmp_path) -> None:
     """--frecency-only skips taxonomy discover."""
+    (tmp_path / ".git").mkdir()
     calls: list[str] = []
 
     def fake_discover(collection_name, taxonomy, chroma_client, *, force=False):
@@ -81,6 +84,7 @@ def test_index_repo_frecency_only_skips_taxonomy(tmp_path) -> None:
 
 def test_index_repo_taxonomy_failure_nonfatal(tmp_path) -> None:
     """Taxonomy discover failure does not fail indexing."""
+    (tmp_path / ".git").mkdir()
     def bad_discover(*a, **kw):
         raise RuntimeError("taxonomy broke")
 

--- a/tests/test_index_taxonomy_skip.py
+++ b/tests/test_index_taxonomy_skip.py
@@ -48,6 +48,7 @@ def test_all_skip_run_skips_postprocessing(runner: CliRunner, index_home: Path) 
     # 0 files changed AND taxonomy already built (topics exist) → skip.
     repo = index_home / "myrepo"
     repo.mkdir()
+    (repo / ".git").mkdir()
 
     result, post = _run(runner, repo, {"files_changed": 0}, taxonomy_incomplete=False)
 
@@ -61,6 +62,7 @@ def test_all_skip_but_taxonomy_incomplete_still_runs(runner: CliRunner, index_ho
     # (discover never succeeded) → discovery must still run.
     repo = index_home / "myrepo"
     repo.mkdir()
+    (repo / ".git").mkdir()
 
     result, post = _run(runner, repo, {"files_changed": 0}, taxonomy_incomplete=True)
 
@@ -72,6 +74,7 @@ def test_all_skip_but_taxonomy_incomplete_still_runs(runner: CliRunner, index_ho
 def test_changed_run_runs_postprocessing(runner: CliRunner, index_home: Path) -> None:
     repo = index_home / "myrepo"
     repo.mkdir()
+    (repo / ".git").mkdir()
 
     # files_changed > 0 short-circuits — runs even when taxonomy looks complete.
     result, post = _run(runner, repo, {"files_changed": 3}, taxonomy_incomplete=False)
@@ -142,6 +145,7 @@ def test_rdr_only_run_still_runs_postprocessing(runner: CliRunner, index_home: P
     # content change: files_changed folds in rdr_indexed, so discovery runs.
     repo = index_home / "myrepo"
     repo.mkdir()
+    (repo / ".git").mkdir()
 
     result, post = _run(runner, repo, {"files_changed": 2, "rdr_indexed": 2}, taxonomy_incomplete=False)
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -441,7 +441,7 @@ def test_run_index_returns_rdr_stats(tmp_path):
 @pytest.mark.parametrize("rdr_indexed,expect", [(1, True), (0, False)])
 def test_index_repo_cmd_rdr_summary(tmp_path, rdr_indexed, expect):
     from click.testing import CliRunner; from nexus.cli import main
-    repo = tmp_path / "repo"; repo.mkdir()
+    repo = tmp_path / "repo"; repo.mkdir(); (repo / ".git").mkdir()
     stats = {"rdr_indexed": rdr_indexed, "rdr_current": 0, "rdr_failed": 0}
     runner = CliRunner()
     with patch("nexus.commands.index._registry_path", return_value=tmp_path / "r.json"), \


### PR DESCRIPTION
## Summary

Real incident 2026-07-10: `nx index repo ~/git` was run against the parent of many repos instead of a specific repo subdirectory. `git rev-parse` fails on a non-repo path, `_resolve_main_repo` falls back to using the path as-is (correct behavior for its other callers), and the CLI silently registered a bogus owner named `"git"` that swept in an unrelated project's files. Discovered via `nx catalog doctor --t3-vs-catalog` surfacing it as a catalog document with no matching T3 collection (filed as part of `nexus-g2zwy`'s investigation).

`nx index repo` now refuses a `PATH` with no `.git` (file or directory — git worktrees use a `.git` file), with an error message pointing at the actual mistake pattern:

```
Error: /Users/hal/git has no .git — this does not look like a repository root.
If you meant to index a specific repo, pass its path directly
(e.g. ~/git/myrepo, not ~/git).
```

No escape hatch — there's no documented legitimate use case for indexing a non-git directory through this command.

## Test plan
- [x] New test: refuses a directory with no `.git`
- [x] New test: still accepts a git worktree (`.git` as a file, not a directory)
- [x] Fixed 6 existing test files whose repo fixtures created bare directories with no `.git`, implicitly relying on the guard not existing (`test_index_cmd.py`, `test_index_lock.py`, `test_index_reminder.py`, `test_index_taxonomy.py`, `test_index_taxonomy_skip.py`, `test_indexer.py`)
- [x] `uv run pytest tests/test_index_cmd.py tests/test_index_lock.py tests/test_index_reminder.py tests/test_index_taxonomy.py tests/test_index_taxonomy_skip.py tests/test_indexer.py -q` — 205 passed
- [x] Full local suite green on this branch before the split (12723 passed) — this PR is purely a subset of that already-verified tree