### PR TITLE
release: conexus 6.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v6.7.0"
+        "ref": "v6.7.1"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "6.7.0"
+      "version": "6.7.1"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v6.7.0"
+        "ref": "v6.7.1"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "6.7.0"
+      "version": "6.7.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.7.1] - 2026-07-14
+
+Bugfix release: every fix below was found by live post-release dogfooding of
+6.7.0 against a real service-mode install (the shakeout the release deserved).
+
+### Fixed
+
+- **Metadata-filtered search no longer dies in service mode.** The MCP
+  `search` tool's `where=` path (including the 6.7.0 range operators)
+  crashed with "catalog._db is unavailable in service mode" for any
+  catalog-mappable key (`page_count`, `bib_year`, ...): the best-effort
+  catalog prefilter used `getattr(catalog, "_db", None)`, but the
+  service-mode client's `_db` is a deliberately RAISING property, which
+  `getattr` propagates instead of defaulting. The prefilter now falls
+  through to standard post-filtering as its contract always claimed.
+- **`nx catalog reconcile` is usable on real service-mode catalogs.** The
+  walk issued 2-3 HTTP round-trips per gapped document with zero output —
+  1h42m and still running on a 21,835-doc catalog. T3 fetches now batch per
+  collection (paged `$in` over content hashes), the pass emits a scan header
+  and per-collection progress lines, and the same catalog heals in ~4
+  minutes. The summary separates `chunks LOST (real gap)` from
+  `never-chunked (expected)` so a real regression can never hide in
+  thousands of expected empty-file entries.
+- **Re-index actually repairs manifest-less documents (the permanent-skip
+  ghost class).** The staleness check keys on T3 chunk state only, so a
+  document whose chunks survived in T3 but whose manifest rows were dropped
+  was skipped as "current" forever — invisible to every catalog-routed
+  surface, with `--force` (whole-repo re-embed) the only cure. `nx index
+  repo` now runs an owner-scoped manifest self-heal (the shared reconcile
+  core) after per-file indexing and before orphan GC: gaps rebuild from the
+  T3 chunks already stored, with no re-embedding, yielding to foreground
+  interactive writers.
+- **Orphan GC can no longer mass-delete live chunks on a manifest defect.**
+  A partial manifest gap once classified 6 live RDR documents' chunks as
+  orphans and deleted them. The GC now refuses any sweep condemning more
+  than `NX_GC_FLOOR_FRACTION` (default 0.25 — chosen to catch the actual
+  27.9% field incident shape) of a collection's decidable chunks at >= 100
+  chunks, with `NX_GC_FORCE=1` as the explicit override, and logs a
+  per-document identity sample for every executed prune.
+
+### Changed
+
+- The local-service gate is fully self-provisioning: it stamps its dev jar
+  from the engine floor, pins pytest to the scratch config dir (no more
+  reads of the operator's real `~/.config/nexus`), and supports
+  `NEXUS_GATE_NO_VOYAGE=1` to mask an absent Voyage key (skip-with-reason
+  instead of hard failure; a present-but-dead key still fails loud).
+
 ## [6.7.0] - 2026-07-13
 
 ### Added

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the conexus plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.7.1] - 2026-07-14
+
+Plugin version aligned with conexus 6.7.1. Plugin-relevant fix: the MCP
+`search` tool's `where=` metadata filtering works in service mode again.
+
 ## [6.7.0] - 2026-07-13
 
 Plugin version aligned with conexus 6.7.0. Plugin-side surface: the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -635,9 +635,17 @@ nx catalog reconcile [--dry-run]
 
 Repairs `document_chunks` manifest gaps left by a persistently-failed manifest-write hook (e.g. the catalog engine-service was briefly unreachable during indexing). A gap is a document with `chunk_count > 0` but fewer manifest rows than that (including zero) — such a document silently drops out of catalog-aware retrieval even though T3 still has its chunks.
 
-For each gapped document, rebuilds its manifest from the T3 chunks in its `physical_collection`, matched by the whole-file `content_hash` recorded on both the document and every one of its chunks, ordered by character/line span. Documents with no `content_hash` recorded, or no matching T3 chunks, are reported as unmatched rather than silently skipped. `--dry-run` reports the same counts without writing.
+For each gapped document, rebuilds its manifest from the T3 chunks in its `physical_collection`, matched by the whole-file `content_hash` recorded on both the document and every one of its chunks, ordered by character/line span. T3 fetches are batched per collection (a paged `$in` over content hashes), and the pass emits a scan header plus per-collection progress lines — on a 21k-document service-mode catalog a full pass takes minutes, not hours. `--dry-run` reports the same counts without writing.
+
+The summary splits unmatched documents into two classes so real regressions are never buried in expected noise: `N with chunks LOST (real gap)` (the document recorded chunks but T3 no longer has them — investigate) versus `M never-chunked (expected: nothing to rebuild)` (e.g. empty `__init__.py` files that legitimately produced no chunks).
+
+`nx index repo` also runs this heal automatically (owner-scoped) after per-file indexing and before orphan GC, so manifest gaps self-repair on the next index without re-embedding. The manual verb remains useful for catalog-wide passes.
 
 Also see the end-of-run summary on `nx index repo`: a persistent manifest-write failure during indexing is now surfaced there (`WARNING: catalog manifest write failed for N document(s)`) with a pointer to this command.
+
+#### Orphan-GC safety floor (environment knobs)
+
+The `nx index repo` orphan GC refuses a sweep that would delete more than `NX_GC_FLOOR_FRACTION` (default `0.25`) of a collection's decidable chunks when at least 100 chunks are condemned — that shape is almost always a manifest defect (the misclassification class that once deleted 6 live documents), not a real cleanup. The refusal is logged with counts and the verification path (`nx catalog doctor --t3-vs-catalog`, `nx catalog reconcile`). Set `NX_GC_FORCE=1` to override after confirming the chunks are genuinely dead. Every executed prune logs a per-document identity sample.
 
 ### nx catalog orphans
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "6.7.0"
+version = "6.7.1"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=6.7.0",
+    "conexus[local]>=6.7.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "6.7.0"
+version = "6.7.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/catalog/manifest_heal.py
+++ b/src/nexus/catalog/manifest_heal.py
@@ -50,6 +50,7 @@ class ManifestHealResult:
     gapped: int = 0
     ghost_gapped: int = 0  # gapped subset with chunk_count == 0
     reconciled: int = 0
+    write_failed: int = 0
     dup_collapsed: int = 0
     dup_old_total: int = 0
     dup_new_total: int = 0
@@ -80,11 +81,12 @@ def _order_key(pair: tuple) -> tuple:
 def heal_manifest_gaps(
     entries: list,
     cat: Any,
-    t3: Any,
-    writer: Any | None,
+    t3_factory: Callable[[], Any],
+    writer_factory: Callable[[], Any] | None,
     *,
     dry_run: bool = False,
     echo: Callable[[str], None] | None = None,
+    yield_before_write: Callable[[], None] | None = None,
 ) -> ManifestHealResult:
     """Detect and rebuild manifest gaps for *entries*.
 
@@ -94,14 +96,23 @@ def heal_manifest_gaps(
             Filtered here to indexable candidates (``chunk_count > 0`` OR
             the ghost shape: recorded content_hash + physical_collection).
         cat: Catalog READER (``get_manifests``).
-        t3: T3 database handle (``get_collection``).
-        writer: Catalog WRITER (``atomic_manifest_replace`` +
-            ``resync_chunk_count_cache``). May be ``None`` only when
-            *dry_run* is True.
+        t3_factory: Zero-arg factory for the T3 handle. Called LAZILY,
+            only after gap detection finds work (review 4711f521 Medium-1:
+            the eager form constructed a real writer + T3 client on every
+            nothing-to-do invocation). The core closes what it creates.
+        writer_factory: Zero-arg factory for the catalog WRITER
+            (``atomic_manifest_replace`` + ``resync_chunk_count_cache``).
+            May be ``None`` only when *dry_run* is True. Same lazy + close
+            contract as *t3_factory*.
         dry_run: Report without writing.
         echo: Optional line sink for progress output (the observability
             half of nexus-8g0ch: a silent long walk reads as a hang).
             ``None`` degrades to structlog-only.
+        yield_before_write: Optional fairness hook invoked before EVERY
+            manifest write (review 4711f521: the indexer threads the
+            RDR-146 P2 ``await_fair_window`` through here so a large heal
+            backlog cannot starve a foreground interactive writer — the
+            GH #1046 class).
     """
     say = echo or (lambda _s: None)
     result = ManifestHealResult()
@@ -135,6 +146,11 @@ def heal_manifest_gaps(
     from nexus.indexer import _paginated_get  # noqa: PLC0415 — deferred: nexus.indexer is heavy and imports back into catalog
     from nexus.mcp_infra import _manifest_chunk_rows  # noqa: PLC0415 — deferred: circular-dep avoidance
 
+    # Lazy instantiation (review 4711f521 Medium-1): only a run with real
+    # gaps pays for a T3 client + catalog writer. The core closes both.
+    t3 = t3_factory()
+    writer = writer_factory() if (writer_factory and not dry_run) else None
+
     def _classify_unmatched(entry: Any) -> None:
         (result.never_chunked if entry.chunk_count == 0
          else result.lost).append(entry)
@@ -147,6 +163,44 @@ def heal_manifest_gaps(
             continue
         by_coll[entry.physical_collection].append((entry, content_hash))
 
+    try:
+        _heal_collections(
+            by_coll, t3, writer, result, say,
+            dry_run=dry_run, yield_before_write=yield_before_write,
+            classify_unmatched=_classify_unmatched,
+            paginated_get=_paginated_get,
+            manifest_chunk_rows=_manifest_chunk_rows,
+        )
+    finally:
+        for handle in (t3, writer):
+            close = getattr(handle, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # noqa: BLE001 — best-effort handle cleanup
+                    pass
+
+    return result
+
+
+def _heal_collections(
+    by_coll: dict,
+    t3: Any,
+    writer: Any | None,
+    result: ManifestHealResult,
+    say: Callable[[str], None],
+    *,
+    dry_run: bool,
+    yield_before_write: Callable[[], None] | None,
+    classify_unmatched: Callable[[Any], None],
+    paginated_get: Any,
+    manifest_chunk_rows: Any,
+) -> None:
+    """The per-collection fetch + rebuild walk (split from the entry point
+    so handle cleanup wraps it in one place)."""
+    _classify_unmatched = classify_unmatched
+    _paginated_get = paginated_get
+    _manifest_chunk_rows = manifest_chunk_rows
     for coll_i, (coll_name, pairs) in enumerate(sorted(by_coll.items()), 1):
         try:
             col = t3.get_collection(coll_name)
@@ -235,12 +289,23 @@ def heal_manifest_gaps(
                 result.dup_old_total += entry.chunk_count
                 result.dup_new_total += len(chunks)
             if not dry_run:
-                writer.atomic_manifest_replace(str(entry.tumbler), chunks)
-                # atomic_manifest_replace's local-SQLite path re-derives
-                # chunk_count in-transaction, but the HTTP/service-mode path
-                # only resyncs when told to — without this the gap detector
-                # re-flags the same documents forever (GH #1371 follow-up).
-                writer.resync_chunk_count_cache(str(entry.tumbler))
+                try:
+                    # RDR-146 P2 fairness: a large heal backlog must yield to
+                    # a foreground interactive writer (GH #1046 class).
+                    if yield_before_write is not None:
+                        yield_before_write()
+                    writer.atomic_manifest_replace(str(entry.tumbler), chunks)
+                    # atomic_manifest_replace's local-SQLite path re-derives
+                    # chunk_count in-transaction, but the HTTP/service-mode
+                    # path only resyncs when told to — without this the gap
+                    # detector re-flags the same documents forever (GH #1371
+                    # follow-up).
+                    writer.resync_chunk_count_cache(str(entry.tumbler))
+                except Exception as exc:  # noqa: BLE001 — critique 4711f521 Sig-3: a mid-pass write failure must not lose the progress accounting
+                    _log.warning(
+                        "manifest_heal_write_failed",
+                        tumbler=str(entry.tumbler), error=str(exc),
+                    )
+                    result.write_failed += 1
+                    continue
             result.reconciled += 1
-
-    return result

--- a/src/nexus/catalog/manifest_heal.py
+++ b/src/nexus/catalog/manifest_heal.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Shared manifest-gap heal core (nexus-8g0ch + nexus-c21fk).
+
+One implementation of "find documents whose ``document_chunks`` manifest is
+missing rows and rebuild it from the T3 chunks already stored" — consumed by
+BOTH ``nx catalog reconcile`` (operator verb, whole-catalog scope) and the
+``nx index repo`` catalog hook (self-heal pass, owner scope).
+
+Why the indexer needs it (nexus-c21fk, GH #1397 field find): the staleness
+check keys on T3 chunk state only — a document whose chunks exist in T3 but
+whose manifest rows were dropped (interrupted run, failed hook) is skipped
+as "current" forever, and the post-store manifest hooks that skipped files
+never trigger can never repair it. The documented self-heal advice
+("re-index repairs the manifest") was structurally wrong for exactly the
+documents that needed it. This core rebuilds the manifest WITHOUT
+re-embedding: the chunk rows are fetched back from T3 (batched ``$in`` over
+whole-file content hashes, 8g0ch), ordered by their spans, and written
+through the same atomic-replace path the indexer uses.
+
+Never-chunked documents (``chunk_count == 0`` and T3 genuinely has no rows —
+e.g. empty ``__init__.py``) are reported as expected, not as gaps: the live
+2026-07-13 heal run found ~8.6k of them, and burying a real chunks-LOST
+regression under that noise was itself a defect.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+#: Hashes per $in predicate. One top-level predicate (MAX_WHERE_PREDICATES
+#: bounds predicate COUNT, not $in array size — no named constant bounds
+#: that; 64 verified live against the pgvector engine). Documented tradeoff
+#: (critique d470eda1): a batch-fetch failure marks up to this many docs
+#: unmatched at once, vs 1 under the old per-doc loop — accepted because
+#: _paginated_get already retries transients internally, so a surviving
+#: failure is almost always collection-wide anyway.
+IN_BATCH = 64
+
+
+@dataclass
+class ManifestHealResult:
+    """Outcome of one heal pass."""
+
+    candidates: int = 0
+    gapped: int = 0
+    ghost_gapped: int = 0  # gapped subset with chunk_count == 0
+    reconciled: int = 0
+    dup_collapsed: int = 0
+    dup_old_total: int = 0
+    dup_new_total: int = 0
+    #: Entries that could not be matched to T3 chunks, split by class:
+    #: ``lost`` had chunk_count > 0 (a REAL gap — chunks are gone);
+    #: ``never_chunked`` had chunk_count == 0 (expected — nothing to rebuild).
+    lost: list = field(default_factory=list)
+    never_chunked: list = field(default_factory=list)
+
+    @property
+    def unmatched(self) -> list:
+        return self.lost + self.never_chunked
+
+
+def _order_key(pair: tuple) -> tuple:
+    """RDR-108 Phase 3 dropped chunk_index from chunk metadata, so the
+    char/line span is the only ordering signal left; fall back to
+    line_start, then to a stable id sort so identically-spanned rows
+    (both absent) still get a deterministic order."""
+    _cid, m = pair
+    m = m or {}
+    start = m.get("chunk_start_char")
+    if start is None:
+        start = m.get("line_start")
+    return (0, start, _cid) if start is not None else (1, 0, _cid)
+
+
+def heal_manifest_gaps(
+    entries: list,
+    cat: Any,
+    t3: Any,
+    writer: Any | None,
+    *,
+    dry_run: bool = False,
+    echo: Callable[[str], None] | None = None,
+) -> ManifestHealResult:
+    """Detect and rebuild manifest gaps for *entries*.
+
+    Args:
+        entries: Candidate ``CatalogEntry`` rows (any scope — whole catalog
+            for the reconcile verb, one owner for the indexer self-heal).
+            Filtered here to indexable candidates (``chunk_count > 0`` OR
+            the ghost shape: recorded content_hash + physical_collection).
+        cat: Catalog READER (``get_manifests``).
+        t3: T3 database handle (``get_collection``).
+        writer: Catalog WRITER (``atomic_manifest_replace`` +
+            ``resync_chunk_count_cache``). May be ``None`` only when
+            *dry_run* is True.
+        dry_run: Report without writing.
+        echo: Optional line sink for progress output (the observability
+            half of nexus-8g0ch: a silent long walk reads as a hang).
+            ``None`` degrades to structlog-only.
+    """
+    say = echo or (lambda _s: None)
+    result = ManifestHealResult()
+
+    candidates = [
+        e for e in entries
+        if e.chunk_count > 0
+        or ((e.meta or {}).get("content_hash") and e.physical_collection)
+    ]
+    result.candidates = len(candidates)
+    if not candidates:
+        return result
+
+    manifests = cat.get_manifests([str(e.tumbler) for e in candidates])
+    gapped = [
+        e for e in candidates
+        if len(manifests.get(str(e.tumbler), [])) < e.chunk_count
+        or (e.chunk_count == 0 and not manifests.get(str(e.tumbler)))
+    ]
+    result.gapped = len(gapped)
+    result.ghost_gapped = sum(1 for e in gapped if e.chunk_count == 0)
+    if not gapped:
+        return result
+
+    say(
+        f"Scanning: {result.candidates} candidate(s), {result.gapped} gapped "
+        f"({result.ghost_gapped} ghost-class chunk_count==0); rebuilding "
+        f"manifests from T3 chunks…"
+    )
+
+    from nexus.indexer import _paginated_get  # noqa: PLC0415 — deferred: nexus.indexer is heavy and imports back into catalog
+    from nexus.mcp_infra import _manifest_chunk_rows  # noqa: PLC0415 — deferred: circular-dep avoidance
+
+    def _classify_unmatched(entry: Any) -> None:
+        (result.never_chunked if entry.chunk_count == 0
+         else result.lost).append(entry)
+
+    by_coll: dict[str, list] = defaultdict(list)
+    for entry in gapped:
+        content_hash = (entry.meta or {}).get("content_hash", "")
+        if not content_hash or not entry.physical_collection:
+            _classify_unmatched(entry)
+            continue
+        by_coll[entry.physical_collection].append((entry, content_hash))
+
+    for coll_i, (coll_name, pairs) in enumerate(sorted(by_coll.items()), 1):
+        try:
+            col = t3.get_collection(coll_name)
+        except Exception as exc:  # noqa: BLE001 — boundary catch; one collection's failure must not abort the pass
+            _log.warning(
+                "manifest_heal_collection_unavailable",
+                collection=coll_name, docs=len(pairs), error=str(exc),
+            )
+            for e, _ in pairs:
+                _classify_unmatched(e)
+            say(
+                f"  [{coll_i}/{len(by_coll)}] {coll_name}: "
+                f"UNAVAILABLE — {len(pairs)} doc(s) unmatched"
+            )
+            continue
+
+        # hash -> (ids, metas), shared across docs with identical content.
+        rows_by_hash: dict[str, tuple[list, list]] = defaultdict(
+            lambda: ([], [])
+        )
+        hashes = sorted({ch for _, ch in pairs})
+        fetched_rows = 0
+        fetch_failed_docs = 0
+        for i in range(0, len(hashes), IN_BATCH):
+            batch = hashes[i:i + IN_BATCH]
+            try:
+                fetched = _paginated_get(
+                    col, include=["metadatas"],
+                    where={"content_hash": {"$in": batch}},
+                )
+            except Exception as exc:  # noqa: BLE001 — boundary catch; parity with the old per-doc failure semantics
+                _log.warning(
+                    "manifest_heal_t3_fetch_failed",
+                    collection=coll_name, batch_size=len(batch),
+                    error=str(exc),
+                )
+                batch_set = set(batch)
+                dropped = [e for e, ch in pairs if ch in batch_set]
+                for e in dropped:
+                    _classify_unmatched(e)
+                fetch_failed_docs += len(dropped)
+                pairs = [(e, ch) for e, ch in pairs if ch not in batch_set]
+                continue
+            for cid, m in zip(
+                fetched.get("ids") or [], fetched.get("metadatas") or [],
+            ):
+                h = (m or {}).get("content_hash", "")
+                if h:
+                    rows_by_hash[h][0].append(cid)
+                    rows_by_hash[h][1].append(m)
+                    fetched_rows += 1
+        # Review d470eda1 Medium-1: a batch-fetch failure mid-collection
+        # must be VISIBLE in the progress line, not just structlog.
+        fetch_note = (
+            f", {fetch_failed_docs} doc(s) unmatched (fetch error)"
+            if fetch_failed_docs else ""
+        )
+        say(
+            f"  [{coll_i}/{len(by_coll)}] {coll_name}: {len(pairs)} doc(s), "
+            f"{fetched_rows} chunk row(s) fetched{fetch_note}"
+        )
+
+        for entry, content_hash in pairs:
+            ids, metas = rows_by_hash.get(content_hash, ([], []))
+            if not ids:
+                _classify_unmatched(entry)
+                continue
+            ordered = sorted(zip(ids, metas), key=_order_key)
+            indexed_metas = []
+            for i, (cid, m) in enumerate(ordered):
+                m = dict(m or {})
+                if not m.get("chunk_text_hash"):
+                    m["chunk_text_hash"] = cid
+                m["chunk_index"] = i
+                indexed_metas.append((i, m))
+            chunks = _manifest_chunk_rows(indexed_metas)
+            if not any(c["chash"] for c in chunks):
+                _classify_unmatched(entry)
+                continue
+            if len(chunks) < entry.chunk_count:
+                # RDR-108: duplicate chunk text collapses to one T3 row by
+                # design, so a rebuilt manifest can legitimately have fewer
+                # rows than the document's stale chunk_count. Not an error —
+                # tracked so the summary reports it instead of hiding it.
+                result.dup_collapsed += 1
+                result.dup_old_total += entry.chunk_count
+                result.dup_new_total += len(chunks)
+            if not dry_run:
+                writer.atomic_manifest_replace(str(entry.tumbler), chunks)
+                # atomic_manifest_replace's local-SQLite path re-derives
+                # chunk_count in-transaction, but the HTTP/service-mode path
+                # only resyncs when told to — without this the gap detector
+                # re-flags the same documents forever (GH #1371 follow-up).
+                writer.resync_chunk_count_cache(str(entry.tumbler))
+            result.reconciled += 1
+
+    return result

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -816,7 +816,10 @@ def reconcile_cmd(dry_run: bool) -> None:
         or ((e.meta or {}).get("content_hash") and e.physical_collection)
     ]
     if not entries:
-        click.echo(f"{verb} 0 document(s); 0 could not be matched to chunks.")
+        click.echo(
+            f"{verb} 0 document(s); 0 with chunks LOST (real gap), "
+            "0 never-chunked (expected: nothing to rebuild)."
+        )
         return
 
     manifests = cat.get_manifests([str(e.tumbler) for e in entries])
@@ -829,7 +832,10 @@ def reconcile_cmd(dry_run: bool) -> None:
         or (e.chunk_count == 0 and not manifests.get(str(e.tumbler)))
     ]
     if not gapped:
-        click.echo(f"{verb} 0 document(s); 0 could not be matched to chunks.")
+        click.echo(
+            f"{verb} 0 document(s); 0 with chunks LOST (real gap), "
+            "0 never-chunked (expected: nothing to rebuild)."
+        )
         return
 
     ghost_count = sum(1 for e in gapped if e.chunk_count == 0)
@@ -863,7 +869,14 @@ def reconcile_cmd(dry_run: bool) -> None:
             continue
         by_coll[entry.physical_collection].append((entry, content_hash))
 
-    _IN_BATCH = 64  # hashes per $in predicate (one predicate; well under quota)
+    # Hashes per $in predicate. One top-level predicate (MAX_WHERE_PREDICATES
+    # bounds predicate COUNT, not $in array size — no named constant bounds
+    # that; 64 verified live against the pgvector engine). Documented
+    # tradeoff (critique d470eda1): a batch-fetch failure marks up to
+    # _IN_BATCH docs unmatched at once, vs 1 under the old per-doc loop —
+    # accepted because _paginated_get already retries transients internally,
+    # so a surviving failure is almost always collection-wide anyway.
+    _IN_BATCH = 64
 
     try:
         for coll_i, (coll_name, pairs) in enumerate(sorted(by_coll.items()), 1):
@@ -887,6 +900,7 @@ def reconcile_cmd(dry_run: bool) -> None:
             )
             hashes = sorted({ch for _, ch in pairs})
             fetched_rows = 0
+            fetch_failed_docs = 0
             for i in range(0, len(hashes), _IN_BATCH):
                 batch = hashes[i:i + _IN_BATCH]
                 try:
@@ -901,9 +915,9 @@ def reconcile_cmd(dry_run: bool) -> None:
                         error=str(exc),
                     )
                     batch_set = set(batch)
-                    unmatched.extend(
-                        e for e, ch in pairs if ch in batch_set
-                    )
+                    dropped = [e for e, ch in pairs if ch in batch_set]
+                    unmatched.extend(dropped)
+                    fetch_failed_docs += len(dropped)
                     pairs = [(e, ch) for e, ch in pairs if ch not in batch_set]
                     continue
                 for cid, m in zip(
@@ -914,9 +928,16 @@ def reconcile_cmd(dry_run: bool) -> None:
                         rows_by_hash[h][0].append(cid)
                         rows_by_hash[h][1].append(m)
                         fetched_rows += 1
+            # Review d470eda1 Medium-1: a batch-fetch failure mid-collection
+            # must be VISIBLE in the progress line, not just structlog — the
+            # summary otherwise shows a silently smaller doc count.
+            fetch_note = (
+                f", {fetch_failed_docs} doc(s) unmatched (fetch error)"
+                if fetch_failed_docs else ""
+            )
             click.echo(
                 f"  [{coll_i}/{len(by_coll)}] {coll_name}: {len(pairs)} doc(s), "
-                f"{fetched_rows} chunk row(s) fetched"
+                f"{fetched_rows} chunk row(s) fetched{fetch_note}"
             )
 
             for entry, content_hash in pairs:
@@ -979,15 +1000,28 @@ def reconcile_cmd(dry_run: bool) -> None:
         "for duplicate-text collapse)"
         if dup_collapsed else ""
     )
+    # Critique d470eda1: split the unmatched report so the permanent
+    # ghost-noise (never-chunked files — chunk_count==0 and T3 has nothing,
+    # e.g. thousands of empty __init__.py) cannot bury a REAL regression
+    # (chunk_count>0 with rows missing = chunks actually lost). Live run
+    # 2026-07-13: 8,653 unmatched of which ~8,6xx were the expected class.
+    never_chunked = [e for e in unmatched if e.chunk_count == 0]
+    lost = [e for e in unmatched if e.chunk_count > 0]
     click.echo(
         f"{verb} {reconciled} document(s){corrected_note}; "
-        f"{len(unmatched)} could not be matched to chunks."
+        f"{len(lost)} with chunks LOST (real gap), "
+        f"{len(never_chunked)} never-chunked (expected: nothing to rebuild)."
     )
-    if unmatched:
-        for entry in unmatched[:20]:
-            click.echo(f"    {entry.tumbler}  {entry.file_path or entry.title}")
-        if len(unmatched) > 20:
-            click.echo(f"    ... and {len(unmatched) - 20} more")
+    if lost:
+        for entry in lost[:20]:
+            click.echo(f"    LOST {entry.tumbler}  {entry.file_path or entry.title}")
+        if len(lost) > 20:
+            click.echo(f"    ... and {len(lost) - 20} more")
+    if never_chunked:
+        for entry in never_chunked[:5]:
+            click.echo(f"    (empty) {entry.tumbler}  {entry.file_path or entry.title}")
+        if len(never_chunked) > 5:
+            click.echo(f"    ... and {len(never_chunked) - 5} more never-chunked")
 
 
 # ── Backfill helpers ──────────────────────────────────────────────────────────

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -832,6 +832,13 @@ def reconcile_cmd(dry_run: bool) -> None:
         click.echo(f"{verb} 0 document(s); 0 could not be matched to chunks.")
         return
 
+    ghost_count = sum(1 for e in gapped if e.chunk_count == 0)
+    click.echo(
+        f"Scanning: {len(entries)} candidate(s), {len(gapped)} gapped "
+        f"({ghost_count} ghost-class chunk_count==0); rebuilding manifests "
+        f"from T3 chunks…"
+    )
+
     t3 = make_t3()
     writer = _get_catalog_writer() if not dry_run else None
     reconciled = 0
@@ -839,74 +846,128 @@ def reconcile_cmd(dry_run: bool) -> None:
     dup_old_total = 0
     dup_new_total = 0
     unmatched: list = []
-    try:
-        for entry in gapped:
-            content_hash = (entry.meta or {}).get("content_hash", "")
-            if not content_hash or not entry.physical_collection:
-                unmatched.append(entry)
-                continue
-            try:
-                col = t3.get_collection(entry.physical_collection)
-                fetched = _paginated_get(
-                    col, include=["metadatas"],
-                    where={"content_hash": content_hash},
-                )
-            except Exception as exc:  # noqa: BLE001 — boundary catch; a T3 fetch failure for one doc must not abort the whole reconcile pass
-                _log.warning(
-                    "catalog_reconcile_t3_fetch_failed",
-                    tumbler=str(entry.tumbler), error=str(exc),
-                )
-                unmatched.append(entry)
-                continue
-            ids = fetched.get("ids") or []
-            metas = fetched.get("metadatas") or []
-            if not ids:
-                unmatched.append(entry)
-                continue
-            # RDR-108 Phase 3 dropped chunk_index from chunk metadata, so
-            # the char/line span is the only ordering signal left; fall
-            # back to line_start, then to a stable id sort so identically-
-            # spanned rows (both absent) still get a deterministic order.
-            def _order_key(pair: tuple) -> tuple:
-                _cid, m = pair
-                m = m or {}
-                start = m.get("chunk_start_char")
-                if start is None:
-                    start = m.get("line_start")
-                return (0, start, _cid) if start is not None else (1, 0, _cid)
 
-            ordered = sorted(zip(ids, metas), key=_order_key)
-            indexed_metas = []
-            for i, (cid, m) in enumerate(ordered):
-                m = dict(m or {})
-                if not m.get("chunk_text_hash"):
-                    m["chunk_text_hash"] = cid
-                m["chunk_index"] = i
-                indexed_metas.append((i, m))
-            chunks = _manifest_chunk_rows(indexed_metas)
-            if not any(c["chash"] for c in chunks):
-                unmatched.append(entry)
+    # nexus-8g0ch: group by physical_collection and batch-fetch chunk rows
+    # with a paged ``$in`` over content hashes. The prior shape issued 2-3
+    # HTTP round-trips PER gapped document — 1h42m+ on a service-mode
+    # catalog with 8.7k gapped docs — for a walk that is now a few hundred
+    # calls total. Per-collection progress lines keep a long pass legible
+    # (observability doctrine: a silent long walk reads as a hang).
+    from collections import defaultdict  # noqa: PLC0415 — command-local
+
+    by_coll: dict[str, list] = defaultdict(list)
+    for entry in gapped:
+        content_hash = (entry.meta or {}).get("content_hash", "")
+        if not content_hash or not entry.physical_collection:
+            unmatched.append(entry)
+            continue
+        by_coll[entry.physical_collection].append((entry, content_hash))
+
+    _IN_BATCH = 64  # hashes per $in predicate (one predicate; well under quota)
+
+    try:
+        for coll_i, (coll_name, pairs) in enumerate(sorted(by_coll.items()), 1):
+            try:
+                col = t3.get_collection(coll_name)
+            except Exception as exc:  # noqa: BLE001 — boundary catch; one collection's failure must not abort the pass
+                _log.warning(
+                    "catalog_reconcile_collection_unavailable",
+                    collection=coll_name, docs=len(pairs), error=str(exc),
+                )
+                unmatched.extend(e for e, _ in pairs)
+                click.echo(
+                    f"  [{coll_i}/{len(by_coll)}] {coll_name}: "
+                    f"UNAVAILABLE — {len(pairs)} doc(s) unmatched"
+                )
                 continue
-            if len(chunks) < entry.chunk_count:
-                # RDR-108: duplicate chunk text collapses to one T3 row by
-                # design, so a rebuilt manifest can legitimately have fewer
-                # rows than the document's stale chunk_count. Not an error —
-                # tracked so the summary reports it instead of hiding it.
-                dup_collapsed += 1
-                dup_old_total += entry.chunk_count
-                dup_new_total += len(chunks)
-            if not dry_run:
-                writer.atomic_manifest_replace(str(entry.tumbler), chunks)
-                # atomic_manifest_replace's local-SQLite path re-derives
-                # chunk_count from the post-write row count in the same
-                # transaction, but the HTTP/service-mode path only resyncs
-                # when new_chunk_count= is passed (which this call site
-                # doesn't do) -- so chunk_count stayed stale forever in
-                # service mode and the gap detector re-flagged the same
-                # documents on every run (GH #1371 follow-up). Explicitly
-                # resyncing here is correct and idempotent on both backends.
-                writer.resync_chunk_count_cache(str(entry.tumbler))
-            reconciled += 1
+
+            # hash -> (ids, metas), shared across docs with identical content.
+            rows_by_hash: dict[str, tuple[list, list]] = defaultdict(
+                lambda: ([], [])
+            )
+            hashes = sorted({ch for _, ch in pairs})
+            fetched_rows = 0
+            for i in range(0, len(hashes), _IN_BATCH):
+                batch = hashes[i:i + _IN_BATCH]
+                try:
+                    fetched = _paginated_get(
+                        col, include=["metadatas"],
+                        where={"content_hash": {"$in": batch}},
+                    )
+                except Exception as exc:  # noqa: BLE001 — boundary catch; parity with the old per-doc failure semantics
+                    _log.warning(
+                        "catalog_reconcile_t3_fetch_failed",
+                        collection=coll_name, batch_size=len(batch),
+                        error=str(exc),
+                    )
+                    batch_set = set(batch)
+                    unmatched.extend(
+                        e for e, ch in pairs if ch in batch_set
+                    )
+                    pairs = [(e, ch) for e, ch in pairs if ch not in batch_set]
+                    continue
+                for cid, m in zip(
+                    fetched.get("ids") or [], fetched.get("metadatas") or [],
+                ):
+                    h = (m or {}).get("content_hash", "")
+                    if h:
+                        rows_by_hash[h][0].append(cid)
+                        rows_by_hash[h][1].append(m)
+                        fetched_rows += 1
+            click.echo(
+                f"  [{coll_i}/{len(by_coll)}] {coll_name}: {len(pairs)} doc(s), "
+                f"{fetched_rows} chunk row(s) fetched"
+            )
+
+            for entry, content_hash in pairs:
+                ids, metas = rows_by_hash.get(content_hash, ([], []))
+                if not ids:
+                    unmatched.append(entry)
+                    continue
+                # RDR-108 Phase 3 dropped chunk_index from chunk metadata, so
+                # the char/line span is the only ordering signal left; fall
+                # back to line_start, then to a stable id sort so identically-
+                # spanned rows (both absent) still get a deterministic order.
+                def _order_key(pair: tuple) -> tuple:
+                    _cid, m = pair
+                    m = m or {}
+                    start = m.get("chunk_start_char")
+                    if start is None:
+                        start = m.get("line_start")
+                    return (0, start, _cid) if start is not None else (1, 0, _cid)
+
+                ordered = sorted(zip(ids, metas), key=_order_key)
+                indexed_metas = []
+                for i, (cid, m) in enumerate(ordered):
+                    m = dict(m or {})
+                    if not m.get("chunk_text_hash"):
+                        m["chunk_text_hash"] = cid
+                    m["chunk_index"] = i
+                    indexed_metas.append((i, m))
+                chunks = _manifest_chunk_rows(indexed_metas)
+                if not any(c["chash"] for c in chunks):
+                    unmatched.append(entry)
+                    continue
+                if len(chunks) < entry.chunk_count:
+                    # RDR-108: duplicate chunk text collapses to one T3 row by
+                    # design, so a rebuilt manifest can legitimately have fewer
+                    # rows than the document's stale chunk_count. Not an error —
+                    # tracked so the summary reports it instead of hiding it.
+                    dup_collapsed += 1
+                    dup_old_total += entry.chunk_count
+                    dup_new_total += len(chunks)
+                if not dry_run:
+                    writer.atomic_manifest_replace(str(entry.tumbler), chunks)
+                    # atomic_manifest_replace's local-SQLite path re-derives
+                    # chunk_count from the post-write row count in the same
+                    # transaction, but the HTTP/service-mode path only resyncs
+                    # when new_chunk_count= is passed (which this call site
+                    # doesn't do) -- so chunk_count stayed stale forever in
+                    # service mode and the gap detector re-flagged the same
+                    # documents on every run (GH #1371 follow-up). Explicitly
+                    # resyncing here is correct and idempotent on both backends.
+                    writer.resync_chunk_count_cache(str(entry.tumbler))
+                reconciled += 1
     finally:
         if writer is not None:
             _close = getattr(writer, "close", None)

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -805,21 +805,16 @@ def reconcile_cmd(dry_run: bool) -> None:
 
     cat = _get_catalog()
     entries = cat.all_documents(limit=0)
-    t3 = make_t3()
-    writer = _get_catalog_writer() if not dry_run else None
-    try:
-        # nexus-c21fk: the heal core is shared with the `nx index repo`
-        # self-heal pass — one implementation, two scopes (whole catalog
-        # here; one owner there). Candidate filtering, gap detection, the
-        # batched $in fetch (8g0ch), and the rebuild all live in the core.
-        result = heal_manifest_gaps(
-            entries, cat, t3, writer, dry_run=dry_run, echo=click.echo,
-        )
-    finally:
-        if writer is not None:
-            _close = getattr(writer, "close", None)
-            if callable(_close):
-                _close()
+    # nexus-c21fk: the heal core is shared with the `nx index repo`
+    # self-heal pass — one implementation, two scopes (whole catalog here;
+    # one owner there). Factories are LAZY (review 4711f521 Medium-1): a
+    # nothing-to-reconcile invocation never constructs a T3 client or a
+    # catalog writer; the core closes what it creates.
+    result = heal_manifest_gaps(
+        entries, cat, make_t3,
+        _get_catalog_writer if not dry_run else None,
+        dry_run=dry_run, echo=click.echo,
+    )
 
     corrected_note = (
         f" ({result.dup_collapsed} with chunk_count corrected "

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -798,197 +798,23 @@ def reconcile_cmd(dry_run: bool) -> None:
 
     ``--dry-run`` reports the same counts without writing.
     """
+    from nexus.catalog.manifest_heal import heal_manifest_gaps  # noqa: PLC0415 — deferred import; rare/branch-local path
     from nexus.db import make_t3  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-    from nexus.indexer import _paginated_get  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-    from nexus.mcp_infra import _manifest_chunk_rows  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
 
     verb = "Would reconcile" if dry_run else "Reconciled"
 
     cat = _get_catalog()
-    # Candidates: normal documents (chunk_count > 0) PLUS the GH #1397 ghost
-    # class — chunk_count == 0 rows that DO carry the indexing provenance
-    # (content_hash + physical_collection) needed for a T3 rebuild. Rows with
-    # chunk_count == 0 and no content_hash are register-only ghosts (never
-    # indexed): excluded so they don't spam the unmatched report.
-    entries = [
-        e for e in cat.all_documents(limit=0)
-        if e.chunk_count > 0
-        or ((e.meta or {}).get("content_hash") and e.physical_collection)
-    ]
-    if not entries:
-        click.echo(
-            f"{verb} 0 document(s); 0 with chunks LOST (real gap), "
-            "0 never-chunked (expected: nothing to rebuild)."
-        )
-        return
-
-    manifests = cat.get_manifests([str(e.tumbler) for e in entries])
-    # Gap: fewer manifest rows than chunk_count, OR the ghost shape (zero
-    # count, empty manifest). A ghost heals to chunk_count > 0 via the
-    # post-write resync, so repeated runs converge.
-    gapped = [
-        e for e in entries
-        if len(manifests.get(str(e.tumbler), [])) < e.chunk_count
-        or (e.chunk_count == 0 and not manifests.get(str(e.tumbler)))
-    ]
-    if not gapped:
-        click.echo(
-            f"{verb} 0 document(s); 0 with chunks LOST (real gap), "
-            "0 never-chunked (expected: nothing to rebuild)."
-        )
-        return
-
-    ghost_count = sum(1 for e in gapped if e.chunk_count == 0)
-    click.echo(
-        f"Scanning: {len(entries)} candidate(s), {len(gapped)} gapped "
-        f"({ghost_count} ghost-class chunk_count==0); rebuilding manifests "
-        f"from T3 chunks…"
-    )
-
+    entries = cat.all_documents(limit=0)
     t3 = make_t3()
     writer = _get_catalog_writer() if not dry_run else None
-    reconciled = 0
-    dup_collapsed = 0
-    dup_old_total = 0
-    dup_new_total = 0
-    unmatched: list = []
-
-    # nexus-8g0ch: group by physical_collection and batch-fetch chunk rows
-    # with a paged ``$in`` over content hashes. The prior shape issued 2-3
-    # HTTP round-trips PER gapped document — 1h42m+ on a service-mode
-    # catalog with 8.7k gapped docs — for a walk that is now a few hundred
-    # calls total. Per-collection progress lines keep a long pass legible
-    # (observability doctrine: a silent long walk reads as a hang).
-    from collections import defaultdict  # noqa: PLC0415 — command-local
-
-    by_coll: dict[str, list] = defaultdict(list)
-    for entry in gapped:
-        content_hash = (entry.meta or {}).get("content_hash", "")
-        if not content_hash or not entry.physical_collection:
-            unmatched.append(entry)
-            continue
-        by_coll[entry.physical_collection].append((entry, content_hash))
-
-    # Hashes per $in predicate. One top-level predicate (MAX_WHERE_PREDICATES
-    # bounds predicate COUNT, not $in array size — no named constant bounds
-    # that; 64 verified live against the pgvector engine). Documented
-    # tradeoff (critique d470eda1): a batch-fetch failure marks up to
-    # _IN_BATCH docs unmatched at once, vs 1 under the old per-doc loop —
-    # accepted because _paginated_get already retries transients internally,
-    # so a surviving failure is almost always collection-wide anyway.
-    _IN_BATCH = 64
-
     try:
-        for coll_i, (coll_name, pairs) in enumerate(sorted(by_coll.items()), 1):
-            try:
-                col = t3.get_collection(coll_name)
-            except Exception as exc:  # noqa: BLE001 — boundary catch; one collection's failure must not abort the pass
-                _log.warning(
-                    "catalog_reconcile_collection_unavailable",
-                    collection=coll_name, docs=len(pairs), error=str(exc),
-                )
-                unmatched.extend(e for e, _ in pairs)
-                click.echo(
-                    f"  [{coll_i}/{len(by_coll)}] {coll_name}: "
-                    f"UNAVAILABLE — {len(pairs)} doc(s) unmatched"
-                )
-                continue
-
-            # hash -> (ids, metas), shared across docs with identical content.
-            rows_by_hash: dict[str, tuple[list, list]] = defaultdict(
-                lambda: ([], [])
-            )
-            hashes = sorted({ch for _, ch in pairs})
-            fetched_rows = 0
-            fetch_failed_docs = 0
-            for i in range(0, len(hashes), _IN_BATCH):
-                batch = hashes[i:i + _IN_BATCH]
-                try:
-                    fetched = _paginated_get(
-                        col, include=["metadatas"],
-                        where={"content_hash": {"$in": batch}},
-                    )
-                except Exception as exc:  # noqa: BLE001 — boundary catch; parity with the old per-doc failure semantics
-                    _log.warning(
-                        "catalog_reconcile_t3_fetch_failed",
-                        collection=coll_name, batch_size=len(batch),
-                        error=str(exc),
-                    )
-                    batch_set = set(batch)
-                    dropped = [e for e, ch in pairs if ch in batch_set]
-                    unmatched.extend(dropped)
-                    fetch_failed_docs += len(dropped)
-                    pairs = [(e, ch) for e, ch in pairs if ch not in batch_set]
-                    continue
-                for cid, m in zip(
-                    fetched.get("ids") or [], fetched.get("metadatas") or [],
-                ):
-                    h = (m or {}).get("content_hash", "")
-                    if h:
-                        rows_by_hash[h][0].append(cid)
-                        rows_by_hash[h][1].append(m)
-                        fetched_rows += 1
-            # Review d470eda1 Medium-1: a batch-fetch failure mid-collection
-            # must be VISIBLE in the progress line, not just structlog — the
-            # summary otherwise shows a silently smaller doc count.
-            fetch_note = (
-                f", {fetch_failed_docs} doc(s) unmatched (fetch error)"
-                if fetch_failed_docs else ""
-            )
-            click.echo(
-                f"  [{coll_i}/{len(by_coll)}] {coll_name}: {len(pairs)} doc(s), "
-                f"{fetched_rows} chunk row(s) fetched{fetch_note}"
-            )
-
-            for entry, content_hash in pairs:
-                ids, metas = rows_by_hash.get(content_hash, ([], []))
-                if not ids:
-                    unmatched.append(entry)
-                    continue
-                # RDR-108 Phase 3 dropped chunk_index from chunk metadata, so
-                # the char/line span is the only ordering signal left; fall
-                # back to line_start, then to a stable id sort so identically-
-                # spanned rows (both absent) still get a deterministic order.
-                def _order_key(pair: tuple) -> tuple:
-                    _cid, m = pair
-                    m = m or {}
-                    start = m.get("chunk_start_char")
-                    if start is None:
-                        start = m.get("line_start")
-                    return (0, start, _cid) if start is not None else (1, 0, _cid)
-
-                ordered = sorted(zip(ids, metas), key=_order_key)
-                indexed_metas = []
-                for i, (cid, m) in enumerate(ordered):
-                    m = dict(m or {})
-                    if not m.get("chunk_text_hash"):
-                        m["chunk_text_hash"] = cid
-                    m["chunk_index"] = i
-                    indexed_metas.append((i, m))
-                chunks = _manifest_chunk_rows(indexed_metas)
-                if not any(c["chash"] for c in chunks):
-                    unmatched.append(entry)
-                    continue
-                if len(chunks) < entry.chunk_count:
-                    # RDR-108: duplicate chunk text collapses to one T3 row by
-                    # design, so a rebuilt manifest can legitimately have fewer
-                    # rows than the document's stale chunk_count. Not an error —
-                    # tracked so the summary reports it instead of hiding it.
-                    dup_collapsed += 1
-                    dup_old_total += entry.chunk_count
-                    dup_new_total += len(chunks)
-                if not dry_run:
-                    writer.atomic_manifest_replace(str(entry.tumbler), chunks)
-                    # atomic_manifest_replace's local-SQLite path re-derives
-                    # chunk_count from the post-write row count in the same
-                    # transaction, but the HTTP/service-mode path only resyncs
-                    # when new_chunk_count= is passed (which this call site
-                    # doesn't do) -- so chunk_count stayed stale forever in
-                    # service mode and the gap detector re-flagged the same
-                    # documents on every run (GH #1371 follow-up). Explicitly
-                    # resyncing here is correct and idempotent on both backends.
-                    writer.resync_chunk_count_cache(str(entry.tumbler))
-                reconciled += 1
+        # nexus-c21fk: the heal core is shared with the `nx index repo`
+        # self-heal pass — one implementation, two scopes (whole catalog
+        # here; one owner there). Candidate filtering, gap detection, the
+        # batched $in fetch (8g0ch), and the rebuild all live in the core.
+        result = heal_manifest_gaps(
+            entries, cat, t3, writer, dry_run=dry_run, echo=click.echo,
+        )
     finally:
         if writer is not None:
             _close = getattr(writer, "close", None)
@@ -996,32 +822,29 @@ def reconcile_cmd(dry_run: bool) -> None:
                 _close()
 
     corrected_note = (
-        f" ({dup_collapsed} with chunk_count corrected {dup_old_total} -> {dup_new_total} "
+        f" ({result.dup_collapsed} with chunk_count corrected "
+        f"{result.dup_old_total} -> {result.dup_new_total} "
         "for duplicate-text collapse)"
-        if dup_collapsed else ""
+        if result.dup_collapsed else ""
     )
-    # Critique d470eda1: split the unmatched report so the permanent
-    # ghost-noise (never-chunked files — chunk_count==0 and T3 has nothing,
-    # e.g. thousands of empty __init__.py) cannot bury a REAL regression
-    # (chunk_count>0 with rows missing = chunks actually lost). Live run
-    # 2026-07-13: 8,653 unmatched of which ~8,6xx were the expected class.
-    never_chunked = [e for e in unmatched if e.chunk_count == 0]
-    lost = [e for e in unmatched if e.chunk_count > 0]
+    # Critique d470eda1: the unmatched report splits permanent ghost-noise
+    # (never-chunked files — nothing to rebuild) from REAL regressions
+    # (chunk_count>0 with rows missing = chunks actually lost).
     click.echo(
-        f"{verb} {reconciled} document(s){corrected_note}; "
-        f"{len(lost)} with chunks LOST (real gap), "
-        f"{len(never_chunked)} never-chunked (expected: nothing to rebuild)."
+        f"{verb} {result.reconciled} document(s){corrected_note}; "
+        f"{len(result.lost)} with chunks LOST (real gap), "
+        f"{len(result.never_chunked)} never-chunked (expected: nothing to rebuild)."
     )
-    if lost:
-        for entry in lost[:20]:
+    if result.lost:
+        for entry in result.lost[:20]:
             click.echo(f"    LOST {entry.tumbler}  {entry.file_path or entry.title}")
-        if len(lost) > 20:
-            click.echo(f"    ... and {len(lost) - 20} more")
-    if never_chunked:
-        for entry in never_chunked[:5]:
+        if len(result.lost) > 20:
+            click.echo(f"    ... and {len(result.lost) - 20} more")
+    if result.never_chunked:
+        for entry in result.never_chunked[:5]:
             click.echo(f"    (empty) {entry.tumbler}  {entry.file_path or entry.title}")
-        if len(never_chunked) > 5:
-            click.echo(f"    ... and {len(never_chunked) - 5} more never-chunked")
+        if len(result.never_chunked) > 5:
+            click.echo(f"    ... and {len(result.never_chunked) - 5} more never-chunked")
 
 
 # ── Backfill helpers ──────────────────────────────────────────────────────────

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1145,6 +1145,44 @@ def _catalog_hook(
         indexed_set = _indexed_relpaths(indexed_files, repo)
         _run_housekeeping(cat, owner, indexed_set, writer=writer)
         _stage_s["housekeeping"] = time.monotonic() - _stage_mark
+        _stage_mark = time.monotonic()
+
+        # nexus-c21fk: manifest self-heal. The staleness check keys on T3
+        # chunk state only, so a doc whose chunks exist in T3 but whose
+        # document_chunks manifest rows were dropped (interrupted run,
+        # failed hook — the GH #1397 class) is skipped as "current"
+        # forever, and the post-store manifest hooks that skipped files
+        # never trigger can never repair it. This pass rebuilds those
+        # manifests from the T3 chunks already stored — NO re-embedding —
+        # via the shared heal core (owner scope; the reconcile verb runs
+        # the same core catalog-wide). Best-effort: a heal failure must
+        # never fail the index run.
+        try:
+            from nexus.catalog.manifest_heal import heal_manifest_gaps  # noqa: PLC0415 — deferred: keeps indexer import-light
+
+            from nexus.db import make_t3  # noqa: PLC0415 — deferred import
+
+            _progress(f"  Catalog: manifest self-heal…\r")
+            heal = heal_manifest_gaps(
+                cat.by_owner(owner), cat, make_t3(), writer,
+            )
+            if heal.reconciled or heal.lost:
+                _progress(
+                    f"  Catalog: manifest self-heal restored "
+                    f"{heal.reconciled} doc(s)"
+                    + (f", {len(heal.lost)} with chunks LOST (real gap — "
+                       "see structlog)" if heal.lost else "")
+                    + "\n"
+                )
+            _log.info(
+                "catalog_manifest_self_heal",
+                candidates=heal.candidates, gapped=heal.gapped,
+                ghost_gapped=heal.ghost_gapped, reconciled=heal.reconciled,
+                lost=len(heal.lost), never_chunked=len(heal.never_chunked),
+            )
+        except Exception:  # noqa: BLE001 — best-effort self-heal; error surfaced via log, must not crash the index run
+            _log.warning("catalog_manifest_self_heal_failed", exc_info=True)
+        _stage_s["manifest_heal"] = time.monotonic() - _stage_mark
         _log.info(
             "catalog_hook_stage_timing",
             total_s=round(time.monotonic() - _stage_t0, 1),

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1145,44 +1145,7 @@ def _catalog_hook(
         indexed_set = _indexed_relpaths(indexed_files, repo)
         _run_housekeeping(cat, owner, indexed_set, writer=writer)
         _stage_s["housekeeping"] = time.monotonic() - _stage_mark
-        _stage_mark = time.monotonic()
 
-        # nexus-c21fk: manifest self-heal. The staleness check keys on T3
-        # chunk state only, so a doc whose chunks exist in T3 but whose
-        # document_chunks manifest rows were dropped (interrupted run,
-        # failed hook — the GH #1397 class) is skipped as "current"
-        # forever, and the post-store manifest hooks that skipped files
-        # never trigger can never repair it. This pass rebuilds those
-        # manifests from the T3 chunks already stored — NO re-embedding —
-        # via the shared heal core (owner scope; the reconcile verb runs
-        # the same core catalog-wide). Best-effort: a heal failure must
-        # never fail the index run.
-        try:
-            from nexus.catalog.manifest_heal import heal_manifest_gaps  # noqa: PLC0415 — deferred: keeps indexer import-light
-
-            from nexus.db import make_t3  # noqa: PLC0415 — deferred import
-
-            _progress(f"  Catalog: manifest self-heal…\r")
-            heal = heal_manifest_gaps(
-                cat.by_owner(owner), cat, make_t3(), writer,
-            )
-            if heal.reconciled or heal.lost:
-                _progress(
-                    f"  Catalog: manifest self-heal restored "
-                    f"{heal.reconciled} doc(s)"
-                    + (f", {len(heal.lost)} with chunks LOST (real gap — "
-                       "see structlog)" if heal.lost else "")
-                    + "\n"
-                )
-            _log.info(
-                "catalog_manifest_self_heal",
-                candidates=heal.candidates, gapped=heal.gapped,
-                ghost_gapped=heal.ghost_gapped, reconciled=heal.reconciled,
-                lost=len(heal.lost), never_chunked=len(heal.never_chunked),
-            )
-        except Exception:  # noqa: BLE001 — best-effort self-heal; error surfaced via log, must not crash the index run
-            _log.warning("catalog_manifest_self_heal_failed", exc_info=True)
-        _stage_s["manifest_heal"] = time.monotonic() - _stage_mark
         _log.info(
             "catalog_hook_stage_timing",
             total_s=round(time.monotonic() - _stage_t0, 1),
@@ -3434,6 +3397,78 @@ def _run_index(
         # files) — the cost was the per-doc serial manifest fetch, now
         # batched inside _prune_misclassified_in_collection (nexus-yz8bt),
         # so the pass stays unconditional AND fast.
+        # nexus-c21fk: manifest self-heal. The staleness check keys on T3
+        # chunk state only, so a doc whose chunks exist in T3 but whose
+        # document_chunks manifest rows were dropped is skipped as
+        # "current" forever — and the post-store manifest hooks that
+        # skipped files never trigger can never repair it. This pass
+        # rebuilds those manifests from the T3 chunks already stored (NO
+        # re-embedding) via the shared heal core. PLACEMENT IS LOAD-BEARING
+        # (critique 4711f521 Critical): it runs AFTER per-file indexing so
+        # gaps created by THIS run's own manifest-write hook are healed
+        # too, and BEFORE the prune passes below so the manifest-keyed GC
+        # (the nexus-mr89x hazard) never sees an unhealed gap. Cost
+        # decision (review 4711f521 Medium-3, accepted deliberately): the
+        # detection is one owner-scoped by_owner + one batched
+        # get_manifests per run — bounded, and the price of self-heal
+        # actually meaning self-heal; ghost-class T3 fetches dedupe to
+        # near-nothing because identical empty files share one
+        # content_hash. Best-effort: a heal failure must never fail the
+        # index run.
+        _phase("Catalog manifest self-heal…")
+        _t = time.monotonic()
+        try:
+            from nexus.catalog.factory import make_catalog_writer as _mk_writer  # noqa: PLC0415 — deferred import
+            from nexus.catalog.manifest_heal import heal_manifest_gaps  # noqa: PLC0415 — deferred: keeps indexer import-light
+            from nexus.db import make_t3 as _mk_t3  # noqa: PLC0415 — deferred import
+
+            if _cat is not None:
+                _, _heal_repo_hash = _repo_identity(repo)
+                _heal_owner = _cat.owner_for_repo(_heal_repo_hash)
+                if _heal_owner is not None:
+                    from nexus.catalog.write_priority import await_fair_window  # noqa: PLC0415 — deferred import
+                    _heal_writer_box: list = []
+
+                    def _tracked_writer():
+                        _heal_writer_box.append(_mk_writer())
+                        return _heal_writer_box[0]
+
+                    def _yield_fair():
+                        # RDR-146 P2: yield to a foreground interactive
+                        # writer before every heal write (GH #1046 class).
+                        if _heal_writer_box:
+                            await_fair_window(
+                                _heal_writer_box[0].is_interactive_write_pending,
+                                on_locked,
+                            )
+
+                    heal = heal_manifest_gaps(
+                        _cat.by_owner(_heal_owner), _cat, _mk_t3,
+                        _tracked_writer, yield_before_write=_yield_fair,
+                    )
+                    if heal.reconciled or heal.lost or heal.write_failed:
+                        _phase(
+                            f"Catalog manifest self-heal: "
+                            f"{heal.reconciled} restored"
+                            + (f", {len(heal.lost)} chunks LOST (real gap)"
+                               if heal.lost else "")
+                            + (f", {heal.write_failed} write failure(s)"
+                               if heal.write_failed else "")
+                        )
+                    _log.info(
+                        "catalog_manifest_self_heal",
+                        candidates=heal.candidates, gapped=heal.gapped,
+                        ghost_gapped=heal.ghost_gapped,
+                        reconciled=heal.reconciled,
+                        write_failed=heal.write_failed,
+                        lost=len(heal.lost),
+                        never_chunked=len(heal.never_chunked),
+                        elapsed_s=round(time.monotonic() - _t, 1),
+                    )
+        except Exception:  # noqa: BLE001 — best-effort self-heal; error surfaced via log, must not crash the index run
+            _log.warning("catalog_manifest_self_heal_failed", exc_info=True)
+        _phase(f"Catalog manifest self-heal done ({time.monotonic() - _t:.1f}s)")
+
         _phase("Pruning misclassified chunks…")
         _t = time.monotonic()
         _prune_misclassified(

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -268,8 +268,43 @@ _CATALOG_REGISTER_PAGE = 1000
 #: plausible real cleanup (tiny collections, test corpora) and refusing
 #: would just nag; at/above it, a >floor-fraction verdict is the
 #: manifest-gap misclassification shape. Pairs with NX_GC_FLOOR_FRACTION
-#: (default 0.5) and the NX_GC_FORCE=1 operator override at the check site.
+#: (default 0.25) and the NX_GC_FORCE=1 operator override at the check site.
 _GC_FLOOR_MIN_CHUNKS = 100
+
+#: Default orphan-fraction floor. 0.25, NOT 0.5 (review e2423e3b Critical-2):
+#: the motivating 2026-07-09 field incident condemned 154/551 chunks = 27.9%
+#: — under a 0.5 floor the exact incident this guard is named for would have
+#: sailed through. The cost asymmetry decides the default: refusing a
+#: legitimate large cleanup defers it behind a loud message + NX_GC_FORCE=1
+#: (recoverable), while allowing a misclassified sweep deletes live data
+#: (not). The c21fk self-heal runs before this GC, so legitimate post-heal
+#: orphan fractions are same-run supersede churn — rarely above a quarter of
+#: a collection.
+_GC_FLOOR_FRACTION_DEFAULT = 0.25
+
+
+def _gc_floor_fraction() -> float:
+    """Parse NX_GC_FLOOR_FRACTION fail-safe (review e2423e3b Critical-1/F6).
+
+    A malformed value must never crash the index run, and nan/inf must not
+    silently neutralize the guard — both fall back to the default with a
+    loud warning. Values are clamped to [0.0, 1.0].
+    """
+    raw = os.environ.get("NX_GC_FLOOR_FRACTION", "")
+    if not raw:
+        return _GC_FLOOR_FRACTION_DEFAULT
+    try:
+        val = float(raw)
+    except ValueError:
+        val = float("nan")
+    if not (0.0 <= val <= 1.0):  # False for nan; excludes inf
+        _log.warning(
+            "gc_floor_fraction_invalid",
+            raw=raw, using=_GC_FLOOR_FRACTION_DEFAULT,
+            note="NX_GC_FLOOR_FRACTION must be a float in [0, 1]",
+        )
+        return _GC_FLOOR_FRACTION_DEFAULT
+    return val
 
 
 def _clear_stale_lock(lock_path: Path) -> None:
@@ -2367,6 +2402,7 @@ def _prune_deleted_files(
             )
             continue
         orphan_ids: list[str] = []
+        orphan_sample: list[dict] = []
         unsafe_skipped = 0
         for chunk_id, meta in zip(all_chunks["ids"], all_chunks["metadatas"]):
             chash = (meta.get("chunk_text_hash") or "")[:32]
@@ -2384,6 +2420,11 @@ def _prune_deleted_files(
                 continue
             if chash not in referenced:
                 orphan_ids.append(chunk_id)
+                if len(orphan_sample) < 20:
+                    orphan_sample.append({
+                        "chash12": chash[:12],
+                        "title": (meta or {}).get("title", ""),
+                    })
         if unsafe_skipped:
             _log.warning("skipped chunks without chunk_text_hash",
                          collection=collection_name,
@@ -2403,9 +2444,13 @@ def _prune_deleted_files(
             # this GC — a surviving mass-orphan verdict is deeply suspect.
             # Legitimate large cleanups stay under the floor or use the
             # explicit override.
-            total = len(all_chunks["ids"])
-            frac = len(orphan_ids) / total
-            floor_frac = float(os.environ.get("NX_GC_FLOOR_FRACTION", "0.5"))
+            # Denominator = DECIDABLE chunks only (review e2423e3b F4): a
+            # collection dominated by undecidable no-chash relics must not
+            # dilute the fraction below the floor while ~all of its
+            # decidable population is condemned.
+            decidable = len(all_chunks["ids"]) - unsafe_skipped
+            frac = len(orphan_ids) / decidable if decidable else 0.0
+            floor_frac = _gc_floor_fraction()
             if (
                 len(orphan_ids) >= _GC_FLOOR_MIN_CHUNKS
                 and frac > floor_frac
@@ -2414,8 +2459,8 @@ def _prune_deleted_files(
                 _log.warning(
                     "gc_safety_floor_refused",
                     collection=collection_name,
-                    orphans=len(orphan_ids), total=total,
-                    fraction=round(frac, 3),
+                    orphans=len(orphan_ids), decidable=decidable,
+                    fraction=round(frac, 3), floor=floor_frac,
                     note=(
                         "refusing to prune: orphan fraction exceeds the "
                         "safety floor — this is the manifest-gap "
@@ -2429,20 +2474,12 @@ def _prune_deleted_files(
                 continue
             # nexus-mr89x (b): per-doc visibility. The field incident gave
             # zero per-doc signal — the operator reverse-engineered the 6
-            # pruned docs from a set difference. Log a bounded identity
-            # sample at INFO; the full id list at DEBUG.
-            _meta_by_id = dict(zip(all_chunks["ids"], all_chunks["metadatas"]))
-            sample = [
-                {
-                    "chash12": ((_meta_by_id.get(cid) or {}).get("chunk_text_hash") or cid)[:12],
-                    "title": (_meta_by_id.get(cid) or {}).get("title", ""),
-                }
-                for cid in orphan_ids[:20]
-            ]
+            # pruned docs from a set difference. The bounded identity sample
+            # was captured inline during classification (review e2423e3b F5).
             _batched_delete(col, orphan_ids)
             _log.info("pruned orphan chunks",
                       collection=collection_name, count=len(orphan_ids),
-                      fraction=round(frac, 3), sample=sample)
+                      fraction=round(frac, 3), sample=orphan_sample)
             _log.debug("pruned orphan chunk ids",
                        collection=collection_name, ids=orphan_ids)
 

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -263,6 +263,14 @@ _LOCK_STALE_SECONDS = 5  # lock files older than this with no live PID are stale
 #: multi-page behaviour without a 1000+ file corpus.
 _CATALOG_REGISTER_PAGE = 1000
 
+#: nexus-mr89x: minimum orphan count before the GC safety floor can refuse a
+#: sweep. Below this, even a 100%-orphan verdict is small enough to be a
+#: plausible real cleanup (tiny collections, test corpora) and refusing
+#: would just nag; at/above it, a >floor-fraction verdict is the
+#: manifest-gap misclassification shape. Pairs with NX_GC_FLOOR_FRACTION
+#: (default 0.5) and the NX_GC_FORCE=1 operator override at the check site.
+_GC_FLOOR_MIN_CHUNKS = 100
+
 
 def _clear_stale_lock(lock_path: Path) -> None:
     """Delete *lock_path* if it is stale (dead PID or old empty file).
@@ -2384,9 +2392,59 @@ def _prune_deleted_files(
                                "to populate chunk_text_hash; until then GC "
                                "cannot decide these chunks safely"))
         if orphan_ids:
+            # nexus-mr89x (a): partial-gap safety floor — the sibling of the
+            # manifest-EMPTY guard above for the manifest-PARTIAL case. A
+            # collection-name stamp mismatch (the nexus-x6kdz class) or a
+            # mass manifest drop classifies ~ALL chunks as orphans; deleting
+            # them is unrecoverable data loss (the 2026-07-09 field incident
+            # pruned 6 live RDR docs). Refuse mass deletion: above the floor
+            # the sweep is far more likely a manifest defect than a real
+            # cleanup, and the c21fk self-heal pass has ALREADY run before
+            # this GC — a surviving mass-orphan verdict is deeply suspect.
+            # Legitimate large cleanups stay under the floor or use the
+            # explicit override.
+            total = len(all_chunks["ids"])
+            frac = len(orphan_ids) / total
+            floor_frac = float(os.environ.get("NX_GC_FLOOR_FRACTION", "0.5"))
+            if (
+                len(orphan_ids) >= _GC_FLOOR_MIN_CHUNKS
+                and frac > floor_frac
+                and os.environ.get("NX_GC_FORCE", "") != "1"
+            ):
+                _log.warning(
+                    "gc_safety_floor_refused",
+                    collection=collection_name,
+                    orphans=len(orphan_ids), total=total,
+                    fraction=round(frac, 3),
+                    note=(
+                        "refusing to prune: orphan fraction exceeds the "
+                        "safety floor — this is the manifest-gap "
+                        "misclassification shape (nexus-mr89x), not a "
+                        "normal cleanup. Verify with `nx catalog doctor "
+                        "--t3-vs-catalog` and `nx catalog reconcile`; "
+                        "override with NX_GC_FORCE=1 only after confirming "
+                        "the chunks are genuinely dead."
+                    ),
+                )
+                continue
+            # nexus-mr89x (b): per-doc visibility. The field incident gave
+            # zero per-doc signal — the operator reverse-engineered the 6
+            # pruned docs from a set difference. Log a bounded identity
+            # sample at INFO; the full id list at DEBUG.
+            _meta_by_id = dict(zip(all_chunks["ids"], all_chunks["metadatas"]))
+            sample = [
+                {
+                    "chash12": ((_meta_by_id.get(cid) or {}).get("chunk_text_hash") or cid)[:12],
+                    "title": (_meta_by_id.get(cid) or {}).get("title", ""),
+                }
+                for cid in orphan_ids[:20]
+            ]
             _batched_delete(col, orphan_ids)
             _log.info("pruned orphan chunks",
-                      collection=collection_name, count=len(orphan_ids))
+                      collection=collection_name, count=len(orphan_ids),
+                      fraction=round(frac, 3), sample=sample)
+            _log.debug("pruned orphan chunk ids",
+                       collection=collection_name, ids=orphan_ids)
 
 
 # ── Main indexing pipeline ───────────────────────────────────────────────────

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -2480,7 +2480,7 @@ def _prune_deleted_files(
             _log.info("pruned orphan chunks",
                       collection=collection_name, count=len(orphan_ids),
                       fraction=round(frac, 3), sample=orphan_sample)
-            _log.debug("pruned orphan chunk ids",
+            _log.debug("pruned_orphan_chunk_ids",
                        collection=collection_name, ids=orphan_ids)
 
 

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -424,7 +424,17 @@ def _prefilter_from_catalog(
     if not where or catalog is None:
         return None
 
-    db = getattr(catalog, "_db", None)
+    # Service-mode HttpCatalogClient deliberately exposes ``_db`` as a
+    # RAISING property (the xnz0o sentinel) — getattr's default only covers
+    # a MISSING attribute, so without the try this best-effort optimization
+    # killed every MCP search carrying a catalog-mappable where key
+    # (page_count, bib_year, ...) in service mode, the shipped default
+    # (found live in the 6.7.0 post-release shakeout). No prefilter is
+    # available over HTTP; fall through to standard post-filtering.
+    try:
+        db = getattr(catalog, "_db", None)
+    except Exception:  # noqa: BLE001 — the sentinel raises by design; prefilter is best-effort
+        return None
     if db is None:
         return None
 

--- a/tests/test_catalog_prefilter.py
+++ b/tests/test_catalog_prefilter.py
@@ -295,3 +295,41 @@ class TestCatalogDocIdsForPredicates:
             )
             doc_ids = _catalog_doc_ids_for_predicates(db, {"bib_year": {"$eq": 2024}})
             assert doc_ids == ["doc-a"]
+
+
+class TestServiceModeRaisingSentinel:
+    """6.7.0 post-release shakeout (live find): the service-mode
+    HttpCatalogClient exposes ``_db`` as a RAISING property (the xnz0o
+    sentinel). ``getattr(obj, "_db", None)`` does NOT default on a raising
+    property — it propagates — so the best-effort prefilter killed every
+    MCP search carrying a catalog-mappable where key (page_count,
+    bib_year, ...) in service mode, the shipped default."""
+
+    def test_raising_db_property_falls_through_to_none(self) -> None:
+        from nexus.search_engine import _prefilter_from_catalog  # noqa: PLC0415 — file pattern: deferred imports
+
+        class _ServiceCatalog:
+            @property
+            def _db(self):
+                raise RuntimeError(
+                    "catalog._db is unavailable in service mode "
+                    "(NX_STORAGE_BACKEND_CATALOG=service)."
+                )
+
+        # Mappable predicate — exactly the shape that reached the sentinel.
+        result = _prefilter_from_catalog(
+            {"page_count": {"$gte": 10}}, _ServiceCatalog(),
+        )
+        assert result is None  # prefilter skipped, never raised
+
+    def test_real_http_catalog_client_sentinel_is_survivable(self) -> None:
+        """Pin against the REAL client class, not just a stand-in — if the
+        sentinel's raise type or property shape changes, this catches it."""
+        from nexus.catalog.http_catalog_client import HttpCatalogClient  # noqa: PLC0415 — file pattern: deferred imports
+        from nexus.search_engine import _prefilter_from_catalog  # noqa: PLC0415 — file pattern: deferred imports
+
+        client = HttpCatalogClient.__new__(HttpCatalogClient)  # no network
+        result = _prefilter_from_catalog(
+            {"bib_year": {"$gte": 2023}}, client,
+        )
+        assert result is None

--- a/tests/test_catalog_reconcile.py
+++ b/tests/test_catalog_reconcile.py
@@ -109,7 +109,7 @@ def test_reconcile_rebuilds_gapped_manifest(t3_db, catalog, runner):
     with patch_reconcile(t3_db, catalog):
         result = runner.invoke(main, ["catalog", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert "Reconciled 1 document(s); 0 could not be matched" in result.output
+    assert "Reconciled 1 document(s); 0 with chunks LOST" in result.output
 
     rows = catalog.get_manifest("1.1.1")
     assert len(rows) == 3
@@ -127,7 +127,7 @@ def test_reconcile_dry_run_reports_without_writing(t3_db, catalog, runner):
     with patch_reconcile(t3_db, catalog):
         result = runner.invoke(main, ["catalog", "reconcile", "--dry-run"])
     assert result.exit_code == 0, result.output
-    assert "Would reconcile 1 document(s); 0 could not be matched" in result.output
+    assert "Would reconcile 1 document(s); 0 with chunks LOST" in result.output
     assert catalog.get_manifest("1.1.1") == []
 
 
@@ -139,7 +139,7 @@ def test_reconcile_reports_unmatched_when_no_content_hash(t3_db, catalog, runner
     with patch_reconcile(t3_db, catalog):
         result = runner.invoke(main, ["catalog", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert "Reconciled 0 document(s); 1 could not be matched" in result.output
+    assert "Reconciled 0 document(s); 1 with chunks LOST" in result.output
     assert "1.1.1" in result.output
 
 
@@ -153,7 +153,7 @@ def test_reconcile_reports_unmatched_when_no_t3_chunks_found(t3_db, catalog, run
     with patch_reconcile(t3_db, catalog):
         result = runner.invoke(main, ["catalog", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert "Reconciled 0 document(s); 1 could not be matched" in result.output
+    assert "Reconciled 0 document(s); 1 with chunks LOST" in result.output
 
 
 def test_reconcile_skips_documents_already_complete(t3_db, catalog, runner):
@@ -168,14 +168,14 @@ def test_reconcile_skips_documents_already_complete(t3_db, catalog, runner):
     with patch_reconcile(t3_db, catalog):
         result = runner.invoke(main, ["catalog", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert "Reconciled 0 document(s); 0 could not be matched" in result.output
+    assert "Reconciled 0 document(s); 0 with chunks LOST" in result.output
 
 
 def test_reconcile_no_gapped_documents_reports_zero(t3_db, catalog, runner):
     with patch_reconcile(t3_db, catalog):
         result = runner.invoke(main, ["catalog", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert "Reconciled 0 document(s); 0 could not be matched" in result.output
+    assert "Reconciled 0 document(s); 0 with chunks LOST" in result.output
 
 
 def patch_reconcile(t3_db, catalog, *, writer=None):
@@ -259,7 +259,7 @@ def test_reconcile_converges_after_one_pass_service_mode_shaped(t3_db, catalog, 
     assert first.exit_code == 0, first.output
     assert "Reconciled 2 document(s)" in first.output
     assert "chunk_count corrected 3 -> 2" in first.output
-    assert "0 could not be matched" in first.output
+    assert "0 with chunks LOST" in first.output
 
     # Manifests + chunk_count both converged after one pass.
     assert len(catalog.get_manifest("1.1.1")) == 2
@@ -272,12 +272,12 @@ def test_reconcile_converges_after_one_pass_service_mode_shaped(t3_db, catalog, 
     with patch_reconcile(t3_db, catalog, writer=writer):
         second = runner.invoke(main, ["catalog", "reconcile"])
     assert second.exit_code == 0, second.output
-    assert "Reconciled 0 document(s); 0 could not be matched" in second.output
+    assert "Reconciled 0 document(s); 0 with chunks LOST" in second.output
 
     with patch_reconcile(t3_db, catalog, writer=writer):
         third = runner.invoke(main, ["catalog", "reconcile", "--dry-run"])
     assert third.exit_code == 0, third.output
-    assert "Would reconcile 0 document(s); 0 could not be matched" in third.output
+    assert "Would reconcile 0 document(s); 0 with chunks LOST" in third.output
 
 
 # ── nexus-94fxl / GH #1397: chunk_count=0 ghost rows ─────────────────────────
@@ -322,13 +322,17 @@ def test_reconcile_zero_ghost_without_content_hash_is_not_noise(t3_db, catalog, 
     with patch_reconcile(t3_db, catalog):
         result = runner.invoke(main, ["catalog", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert "Reconciled 0 document(s); 0 could not be matched" in result.output
+    assert "Reconciled 0 document(s); 0 with chunks LOST" in result.output
 
 
 def test_reconcile_zero_ghost_with_hash_but_no_t3_chunks_reported(t3_db, catalog, runner):
     """A chunk_count=0 row WITH a content_hash but no matching T3 chunks is
     anomalous (the file was hashed for indexing but its chunks are gone) —
-    reported as unmatched, not silently skipped."""
+    reported, not silently skipped. Critique d470eda1 refined the taxonomy:
+    chunk_count==0 ghosts land in the never-chunked (expected) bucket — the
+    live catalog holds ~8.6k of them (empty __init__.py etc.), and burying a
+    REAL chunks-LOST regression under that noise was the defect. Still
+    visible in the report, listed with the (empty) prefix."""
     _seed_doc(
         catalog, tumbler="1.3.151", collection="rdr__nexus",
         chunk_count=0, content_hash="vanished",
@@ -336,7 +340,7 @@ def test_reconcile_zero_ghost_with_hash_but_no_t3_chunks_reported(t3_db, catalog
     with patch_reconcile(t3_db, catalog):
         result = runner.invoke(main, ["catalog", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert "Reconciled 0 document(s); 1 could not be matched" in result.output
+    assert "0 with chunks LOST (real gap), 1 never-chunked" in result.output
     assert "1.3.151" in result.output
 
 
@@ -376,3 +380,133 @@ def test_reconcile_batches_t3_fetches_per_collection(t3_db, catalog, runner):
     # Progress emission (observability half of nexus-8g0ch): per-collection
     # line plus the scan header.
     assert "gapped" in result.output and "code__delos" in result.output
+
+
+def test_reconcile_batch_fetch_failure_marks_batch_unmatched_and_continues(
+    t3_db, catalog, runner,
+):
+    """Review d470eda1 Medium-2: the batch-failure path — a _paginated_get
+    exception marks exactly that batch's docs unmatched (visible in the
+    progress line, not just structlog), and docs in OTHER collections still
+    reconcile. Parity with the old per-doc failure semantics."""
+    from unittest.mock import patch as _patch  # noqa: PLC0415 — file pattern: deferred imports
+
+    import nexus.indexer as indexer_mod  # noqa: PLC0415 — file pattern: deferred imports
+
+    _seed_doc(catalog, tumbler="1.1.1", collection="code__broken",
+              chunk_count=2, content_hash="deadhash")
+    _seed_chunks(t3_db, "code__broken", "deadhash", 2)
+    _seed_doc(catalog, tumbler="1.1.2", collection="code__healthy",
+              chunk_count=2, content_hash="goodhash")
+    _seed_chunks(t3_db, "code__healthy", "goodhash", 2)
+
+    real = indexer_mod._paginated_get
+
+    def failing_for_broken(col, **kwargs):
+        if getattr(col, "name", "") == "code__broken":
+            raise RuntimeError("simulated T3 fetch failure")
+        return real(col, **kwargs)
+
+    with patch_reconcile(t3_db, catalog), \
+            _patch("nexus.indexer._paginated_get", side_effect=failing_for_broken):
+        result = runner.invoke(main, ["catalog", "reconcile"])
+    assert result.exit_code == 0, result.output
+    # The healthy collection reconciled; the broken batch's doc is unmatched.
+    assert "Reconciled 1 document(s); 1 with chunks LOST" in result.output
+    # Medium-1 fix: the failure is VISIBLE in the progress line.
+    assert "1 doc(s) unmatched (fetch error)" in result.output
+    assert catalog.get_manifest("1.1.2") != []
+    assert catalog.get_manifest("1.1.1") == []
+
+
+def test_reconcile_shared_content_hash_resolves_both_docs_from_one_fetch(
+    t3_db, catalog, runner,
+):
+    """Two docs with IDENTICAL content_hash in one collection (the
+    empty-__init__.py shape at scale): both must heal from the shared
+    rows_by_hash bucket, with exactly one $in fetch issued."""
+    from unittest.mock import patch as _patch  # noqa: PLC0415 — file pattern: deferred imports
+
+    import nexus.indexer as indexer_mod  # noqa: PLC0415 — file pattern: deferred imports
+
+    _seed_doc(catalog, tumbler="1.2.1", collection="code__delos",
+              chunk_count=2, content_hash="samehash")
+    _seed_doc(catalog, tumbler="1.2.2", collection="code__delos",
+              chunk_count=2, content_hash="samehash")
+    _seed_chunks(t3_db, "code__delos", "samehash", 2)
+
+    calls: list = []
+    real = indexer_mod._paginated_get
+
+    def counting(col, **kwargs):
+        calls.append(kwargs.get("where") or {})
+        return real(col, **kwargs)
+
+    with patch_reconcile(t3_db, catalog), \
+            _patch("nexus.indexer._paginated_get", side_effect=counting):
+        result = runner.invoke(main, ["catalog", "reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "Reconciled 2 document(s)" in result.output
+    assert len(calls) == 1  # the shared hash dedupes to ONE fetch
+    assert [r.chash for r in catalog.get_manifest("1.2.1")] == \
+        [r.chash for r in catalog.get_manifest("1.2.2")]
+
+
+def test_reconcile_over_64_hashes_pages_the_in_predicate(t3_db, catalog, runner):
+    """The 64-hash $in boundary: 65 unique hashes in one collection must
+    produce exactly TWO batched fetches (64 + 1), never per-doc calls."""
+    from unittest.mock import patch as _patch  # noqa: PLC0415 — file pattern: deferred imports
+
+    import nexus.indexer as indexer_mod  # noqa: PLC0415 — file pattern: deferred imports
+
+    for i in range(65):
+        _seed_doc(catalog, tumbler=f"1.3.{i + 1}", collection="code__delos",
+                  chunk_count=1, content_hash=f"bulk{i:04d}")
+        _seed_chunks(t3_db, "code__delos", f"bulk{i:04d}", 1)
+
+    calls: list = []
+    real = indexer_mod._paginated_get
+
+    def counting(col, **kwargs):
+        calls.append(kwargs.get("where") or {})
+        return real(col, **kwargs)
+
+    with patch_reconcile(t3_db, catalog), \
+            _patch("nexus.indexer._paginated_get", side_effect=counting):
+        result = runner.invoke(main, ["catalog", "reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "Reconciled 65 document(s)" in result.output
+    assert len(calls) == 2
+    assert len(calls[0]["content_hash"]["$in"]) == 64
+    assert len(calls[1]["content_hash"]["$in"]) == 1
+
+
+def test_reconcile_collection_unavailable_reports_and_continues(
+    t3_db, catalog, runner,
+):
+    """get_collection() raising (collection deleted from the service — 14
+    live occurrences on the 2026-07-13 run) emits the UNAVAILABLE progress
+    line, marks that collection's docs unmatched, and the pass continues."""
+    from unittest.mock import patch as _patch  # noqa: PLC0415 — file pattern: deferred imports
+
+    _seed_doc(catalog, tumbler="1.4.1", collection="code__gone",
+              chunk_count=2, content_hash="gonehash")
+    _seed_doc(catalog, tumbler="1.4.2", collection="code__alive",
+              chunk_count=2, content_hash="alivehash")
+    _seed_chunks(t3_db, "code__alive", "alivehash", 2)
+
+    real_get = t3_db.get_collection
+
+    def failing_get(name):
+        if name == "code__gone":
+            raise ValueError(f"collection '{name}' not found in service")
+        return real_get(name)
+
+    with patch_reconcile(t3_db, catalog), \
+            _patch.object(t3_db, "get_collection", side_effect=failing_get):
+        result = runner.invoke(main, ["catalog", "reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "code__gone: UNAVAILABLE — 1 doc(s) unmatched" in result.output
+    assert "Reconciled 1 document(s)" in result.output
+    assert "1 with chunks LOST (real gap)" in result.output
+    assert catalog.get_manifest("1.4.2") != []

--- a/tests/test_catalog_reconcile.py
+++ b/tests/test_catalog_reconcile.py
@@ -338,3 +338,41 @@ def test_reconcile_zero_ghost_with_hash_but_no_t3_chunks_reported(t3_db, catalog
     assert result.exit_code == 0, result.output
     assert "Reconciled 0 document(s); 1 could not be matched" in result.output
     assert "1.3.151" in result.output
+
+
+def test_reconcile_batches_t3_fetches_per_collection(t3_db, catalog, runner):
+    """nexus-8g0ch: the T3 fetch is batched per collection ($in over content
+    hashes), never per document. The pre-fix shape issued 2-3 HTTP round
+    trips PER gapped doc — 1h42m+ on a real 8.7k-gap service-mode catalog.
+    Three gapped docs sharing one collection must cost exactly ONE
+    _paginated_get call (3 unique hashes < the 64-hash batch size)."""
+    from unittest.mock import patch as _patch  # noqa: PLC0415 — file pattern: deferred imports
+
+    import nexus.indexer as indexer_mod  # noqa: PLC0415 — file pattern: deferred imports
+
+    for i in range(1, 4):
+        _seed_doc(
+            catalog, tumbler=f"1.1.{i}", collection="code__delos",
+            chunk_count=2, content_hash=f"hash{i:03d}",
+        )
+        _seed_chunks(t3_db, "code__delos", f"hash{i:03d}", 2)
+
+    calls: list[dict] = []
+    real = indexer_mod._paginated_get
+
+    def counting(col, **kwargs):
+        calls.append(kwargs.get("where") or {})
+        return real(col, **kwargs)
+
+    with patch_reconcile(t3_db, catalog), \
+            _patch("nexus.indexer._paginated_get", side_effect=counting):
+        result = runner.invoke(main, ["catalog", "reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "Reconciled 3 document(s)" in result.output
+
+    assert len(calls) == 1, f"expected ONE batched fetch, got {len(calls)}: {calls}"
+    in_list = calls[0]["content_hash"]["$in"]
+    assert sorted(in_list) == ["hash001", "hash002", "hash003"]
+    # Progress emission (observability half of nexus-8g0ch): per-collection
+    # line plus the scan header.
+    assert "gapped" in result.output and "code__delos" in result.output

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2073,3 +2073,55 @@ def test_drain_markers_on_phase_none_safe():
     from nexus.indexer import _drain_batcher_with_markers
     b = _StubBatcher({"chunks": 5, "collections": 1, "in_flight": 0}, flushes=1)
     assert _drain_batcher_with_markers(b, None) == 1
+
+
+class TestGcSafetyFloor:
+    """nexus-mr89x (a): the partial-gap safety floor — the sibling of the
+    manifest-empty guard for the manifest-PARTIAL case. A collection-name
+    stamp mismatch or mass manifest drop classifies ~all chunks as orphans;
+    the 2026-07-09 field incident pruned 6 live RDR docs that way."""
+
+    @staticmethod
+    def _mass_orphan_setup(n_total=200, n_live=20):
+        """n_total chunks, only n_live referenced -> 90% orphan verdict."""
+        rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(n_total)]
+        live = {r[1][:32] for r in rows[:n_live]}
+        col = _gc_col(rows)
+        db = MagicMock()
+        db.get_or_create_collection.return_value = col
+        db.get_collection.return_value = col
+        catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
+        return col, db, catalog
+
+    def test_mass_orphan_verdict_refused(self, monkeypatch):
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.delenv("NX_GC_FORCE", raising=False)
+        col, db, catalog = self._mass_orphan_setup()
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+        assert _deleted_ids(col) == []  # refused: nothing deleted
+
+    def test_operator_override_allows_the_sweep(self, monkeypatch):
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.setenv("NX_GC_FORCE", "1")
+        col, db, catalog = self._mass_orphan_setup()
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+        assert len(_deleted_ids(col)) == 180  # explicit override sweeps
+
+    def test_under_floor_fraction_prunes_normally(self, monkeypatch):
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.delenv("NX_GC_FORCE", raising=False)
+        # 200 chunks, 120 live -> 40% orphans: under the 50% floor.
+        col, db, catalog = self._mass_orphan_setup(n_total=200, n_live=120)
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+        assert len(_deleted_ids(col)) == 80
+
+    def test_small_collection_exempt_from_floor(self, monkeypatch):
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.delenv("NX_GC_FORCE", raising=False)
+        # ~89% orphan verdict but only 8 orphans (< _GC_FLOOR_MIN_CHUNKS):
+        # plausible real cleanup of a tiny corpus — must still prune.
+        # (n_live=1 keeps the manifest non-empty so the older oqku
+        # empty-manifest guard does not preempt this case.)
+        col, db, catalog = self._mass_orphan_setup(n_total=9, n_live=1)
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+        assert len(_deleted_ids(col)) == 8

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1710,9 +1710,13 @@ def test_on_stage_timers_none_is_safe(tmp_path):
 
 # ── Pagination tests ────────────────────────────────────────────────────────
 
-def test_prune_deleted_files_paginates(tmp_path):
+def test_prune_deleted_files_paginates(tmp_path, monkeypatch):
     """RDR-108 Phase 4 / nexus-dyxe: pagination still walks the whole
-    collection and deletes orphans across page boundaries."""
+    collection and deletes orphans across page boundaries. (This fixture's
+    110/310 = 35.5% orphan fraction trips the nexus-mr89x safety floor by
+    design; the explicit override applies because pagination, not floor
+    policy, is under test — floor policy has its own TestGcSafetyFloor.)"""
+    monkeypatch.setenv("NX_GC_FORCE", "1")
     from nexus.indexer import _prune_deleted_files
     live = [(f"live-{i:03d}", f"a{i:03d}" + "0" * 60) for i in range(200)]
     orphan = [(f"orphan-{i:03d}", f"b{i:03d}" + "0" * 60) for i in range(110)]
@@ -2125,3 +2129,99 @@ class TestGcSafetyFloor:
         col, db, catalog = self._mass_orphan_setup(n_total=9, n_live=1)
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
         assert len(_deleted_ids(col)) == 8
+
+
+class TestGcSafetyFloorReviewHardening:
+    """Review e2423e3b findings: the floor must catch the ACTUAL field
+    incident shape, survive malformed configuration, isolate per
+    collection, and hold at its boundaries."""
+
+    def test_field_incident_shape_is_refused(self, monkeypatch):
+        """Critical-2: the 2026-07-09 incident condemned 154/551 = 27.9% —
+        the original 0.5 default sailed it through. The 0.25 default must
+        refuse exactly this shape."""
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.delenv("NX_GC_FORCE", raising=False)
+        monkeypatch.delenv("NX_GC_FLOOR_FRACTION", raising=False)
+        rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(551)]
+        live = {r[1][:32] for r in rows[:397]}  # 154 orphans = 27.9%
+        col = _gc_col(rows)
+        db = MagicMock()
+        db.get_or_create_collection.return_value = col
+        db.get_collection.return_value = col
+        catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+        assert _deleted_ids(col) == []
+
+    def test_malformed_floor_env_never_crashes_and_keeps_the_guard(
+        self, monkeypatch,
+    ):
+        """Critical-1 + F6: a malformed / nan / inf NX_GC_FLOOR_FRACTION
+        must not crash the index run NOR silently neutralize the guard —
+        it falls back to the default (which refuses a 90% verdict)."""
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.delenv("NX_GC_FORCE", raising=False)
+        for bad in ("not-a-float", "nan", "inf", "-3", "7"):
+            monkeypatch.setenv("NX_GC_FLOOR_FRACTION", bad)
+            rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(200)]
+            live = {r[1][:32] for r in rows[:20]}
+            col = _gc_col(rows)
+            db = MagicMock()
+            db.get_or_create_collection.return_value = col
+            db.get_collection.return_value = col
+            catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
+            _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+            assert _deleted_ids(col) == [], f"guard neutralized by {bad!r}"
+
+    def test_fraction_gate_isolated_at_scale(self, monkeypatch):
+        """F3b: orphans >= the count gate (125 >= 100) but fraction under
+        the floor (125/625 = 20% < 25%) — must prune. Isolates the
+        fraction gate from the count gate."""
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.delenv("NX_GC_FORCE", raising=False)
+        monkeypatch.delenv("NX_GC_FLOOR_FRACTION", raising=False)
+        rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(625)]
+        live = {r[1][:32] for r in rows[:500]}
+        col = _gc_col(rows)
+        db = MagicMock()
+        db.get_or_create_collection.return_value = col
+        db.get_collection.return_value = col
+        catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+        assert len(_deleted_ids(col)) == 125
+
+    def test_exact_floor_fraction_is_not_refused(self, monkeypatch):
+        """Boundary: frac == floor is NOT refused (strict >). 150/600 = 25%
+        exactly at the default floor -> prunes."""
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.delenv("NX_GC_FORCE", raising=False)
+        monkeypatch.delenv("NX_GC_FLOOR_FRACTION", raising=False)
+        rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(600)]
+        live = {r[1][:32] for r in rows[:450]}
+        col = _gc_col(rows)
+        db = MagicMock()
+        db.get_or_create_collection.return_value = col
+        db.get_collection.return_value = col
+        catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+        assert len(_deleted_ids(col)) == 150
+
+    def test_refused_collection_does_not_block_others(self, monkeypatch):
+        """F3: per-collection isolation through DISTINCT collections (the
+        _gc_db pattern the file's own docstring mandates — the shared-mock
+        shortcut masked this contract). code__repo is a mass-orphan refusal;
+        docs__repo has one genuine orphan that must still prune."""
+        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        monkeypatch.delenv("NX_GC_FORCE", raising=False)
+        monkeypatch.delenv("NX_GC_FLOOR_FRACTION", raising=False)
+        code_rows = [(f"code-{i:04d}", f"{i:032d}" + "c" * 32) for i in range(200)]
+        code_live = {r[1][:32] for r in code_rows[:20]}  # 90% orphan -> refuse
+        docs_rows = [("docs-live", "a" * 64), ("docs-orphan", "b" * 64)]
+        db, cols = _gc_db({"code__repo": code_rows, "docs__repo": docs_rows})
+        catalog = _gc_catalog({
+            "code__repo": code_live,
+            "docs__repo": {("a" * 64)[:32]},
+        })
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+        assert _deleted_ids(cols["code__repo"]) == []  # refused
+        assert _deleted_ids(cols["docs__repo"]) == ["docs-orphan"]  # pruned

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -744,3 +744,95 @@ def test_index_repository_pdf_routing(
     pdf_results = [r for r in results if r.get("content_type") == "pdf"]
     assert pdf_results, f"No PDF chunks; content_types: {[r.get('content_type') for r in results]}"
     assert isinstance(pdf_results[0]["title"], str)
+
+
+def test_reindex_self_heals_missing_manifest(
+    rich_repo: Path, local_t3: T3Database, tmp_path: Path,
+) -> None:
+    """nexus-c21fk (GH #1397 field find): the staleness check keys on T3
+    chunk state only, so a doc whose chunks exist in T3 but whose
+    document_chunks manifest rows are gone was PERMANENTLY skipped as
+    'current' — chunk_count frozen at 0, every catalog-routed surface
+    blind to it, and the documented advice ('re-index repairs it')
+    structurally wrong. The exact bead repro: index, delete a doc's
+    manifest rows + zero its chunk_count, re-index. The self-heal pass
+    must rebuild the manifest from T3 WITHOUT re-embedding."""
+    from nexus.catalog.catalog import Catalog  # noqa: PLC0415 — file pattern: deferred imports
+    from nexus.config import catalog_path  # noqa: PLC0415 — file pattern: deferred imports
+
+    cat_path = catalog_path()
+    Catalog.init(cat_path)
+    reg = RepoRegistry(tmp_path / "repos.json")
+    reg.add(rich_repo)
+
+    # TWO settling passes: the first index creates path-derived collection
+    # names; the second triggers the nexus-7vuw legacy-rename migration,
+    # which re-embeds everything and rewrites manifests — masking exactly
+    # the bug under test.
+    _index(rich_repo, reg, local_t3)
+    _index(rich_repo, reg, local_t3)
+
+    cat = Catalog(cat_path, cat_path / ".catalog.db")
+    row = cat._db.execute(
+        "SELECT tumbler, chunk_count FROM documents WHERE file_path = ?",
+        ("README.md",),
+    ).fetchone()
+    assert row is not None
+    tumbler, count_before = row
+    assert count_before > 0
+    manifest_before = cat.get_manifest(tumbler)
+    assert len(manifest_before) > 0
+
+    # Sabotage: the GH #1397 shape — manifest rows gone, chunk_count zeroed.
+    cat._db.execute("DELETE FROM document_chunks WHERE doc_id = ?", (tumbler,))
+    cat._db.execute(
+        "UPDATE documents SET chunk_count = 0 WHERE tumbler = ?", (tumbler,),
+    )
+    cat._db.commit()
+    cat._db.close()
+
+    # Reproduce the FIELD configuration (docs 1.3.142-150, GH #1397): the
+    # stuck population's chunks carry INLINE doc_id metadata (the RDR-101
+    # Phase-4-era write shape), which hits the staleness cache's by_doc_id
+    # index directly — a hit that never consults the manifest, so the doc
+    # is skipped as "current" forever. Without this stamp the fixture's
+    # chunks (no inline doc_id) resolve doc_id THROUGH the manifest
+    # (nexus-0ocy chash fallback), whose absence makes them look stale and
+    # self-heal by re-embedding — masking the bug (verified: this test
+    # passed vacuously before the stamp).
+    info = reg.get(rich_repo)
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+    got = docs_col.get(include=["metadatas"])
+    readme_ids = [
+        cid for cid, m in zip(got["ids"], got["metadatas"])
+        if "README.md" in (m or {}).get("title", "")
+    ]
+    assert readme_ids
+    docs_col.update(
+        ids=readme_ids,
+        metadatas=[{"doc_id": str(tumbler)} for _ in readme_ids],
+    )
+
+    # Snapshot T3 so we can prove the heal never re-embedded anything.
+    ids_before = sorted(docs_col.get()["ids"])
+
+    # README.md is unchanged on disk -> staleness skips it (by_doc_id hit);
+    # only the new self-heal pass can repair the manifest.
+    _index(rich_repo, reg, local_t3)
+
+    cat2 = Catalog(cat_path, cat_path / ".catalog.db")
+    healed = cat2.get_manifest(tumbler)
+    count_after = cat2._db.execute(
+        "SELECT chunk_count FROM documents WHERE tumbler = ?", (tumbler,),
+    ).fetchone()[0]
+    cat2._db.close()
+
+    assert [r.chash for r in healed] == [r.chash for r in manifest_before], (
+        "self-heal must rebuild the exact manifest from T3 chunks"
+    )
+    assert count_after == len(healed) > 0, (
+        "chunk_count must resync from the healed manifest"
+    )
+    assert sorted(docs_col.get()["ids"]) == ids_before, (
+        "the heal must NOT re-embed (T3 chunk set unchanged)"
+    )

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -836,3 +836,50 @@ def test_reindex_self_heals_missing_manifest(
     assert sorted(docs_col.get()["ids"]) == ids_before, (
         "the heal must NOT re-embed (T3 chunk set unchanged)"
     )
+
+
+def test_manifest_self_heal_runs_after_indexing_before_prunes(
+    rich_repo: Path, local_t3: T3Database, tmp_path: Path,
+) -> None:
+    """Critique 4711f521 Critical: the heal's PLACEMENT is load-bearing.
+    It must run AFTER per-file indexing (so gaps created by this run's own
+    manifest-write hook are healed too) and BEFORE the prune passes (so the
+    manifest-keyed GC — the nexus-mr89x hazard — never sees an unhealed
+    gap). Pin the call order."""
+    from nexus.catalog.catalog import Catalog  # noqa: PLC0415 — file pattern: deferred imports
+    from nexus.config import catalog_path  # noqa: PLC0415 — file pattern: deferred imports
+
+    import nexus.indexer as indexer_mod  # noqa: PLC0415 — file pattern: deferred imports
+    from nexus.catalog import manifest_heal as heal_mod  # noqa: PLC0415 — file pattern: deferred imports
+
+    Catalog.init(catalog_path())
+    reg = RepoRegistry(tmp_path / "repos.json")
+    reg.add(rich_repo)
+
+    order: list[str] = []
+    real_heal = heal_mod.heal_manifest_gaps
+    real_prune = indexer_mod._prune_deleted_files
+    real_index_prose = indexer_mod._index_prose_file
+
+    def spy_heal(*a, **k):
+        order.append("heal")
+        return real_heal(*a, **k)
+
+    def spy_prune(*a, **k):
+        order.append("prune")
+        return real_prune(*a, **k)
+
+    def spy_prose(*a, **k):
+        if "index" not in order:
+            order.append("index")
+        return real_index_prose(*a, **k)
+
+    with patch.object(heal_mod, "heal_manifest_gaps", side_effect=spy_heal), \
+            patch.object(indexer_mod, "_prune_deleted_files", side_effect=spy_prune), \
+            patch.object(indexer_mod, "_index_prose_file", side_effect=spy_prose):
+        _index(rich_repo, reg, local_t3)
+
+    assert "heal" in order and "prune" in order and "index" in order
+    assert order.index("index") < order.index("heal") < order.index("prune"), (
+        f"self-heal must run after per-file indexing and before the prunes; got {order}"
+    )

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -784,9 +784,9 @@ def test_reindex_self_heals_missing_manifest(
     assert len(manifest_before) > 0
 
     # Sabotage: the GH #1397 shape — manifest rows gone, chunk_count zeroed.
-    cat._db.execute("DELETE FROM document_chunks WHERE doc_id = ?", (tumbler,))
+    cat._db.execute("DELETE FROM document_chunks WHERE doc_id = ?", (tumbler,))  # epsilon-allow: deliberate corruption injection — the GH #1397 manifest-drop shape under test
     cat._db.execute(
-        "UPDATE documents SET chunk_count = 0 WHERE tumbler = ?", (tumbler,),
+        "UPDATE documents SET chunk_count = 0 WHERE tumbler = ?", (tumbler,),  # epsilon-allow: deliberate corruption injection — the GH #1397 manifest-drop shape under test
     )
     cat._db.commit()
     cat._db.close()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -421,15 +421,33 @@ def test_t3_put_embedding_model_in_search_metadata():
 
 @pytest.mark.integration
 @requires_t3
-@requires_voyage_key
 def test_migrate_t3_ensure_databases_is_idempotent(runner):
-    import os
-    from nexus.commands._provision import ensure_databases, _cloud_admin_client
+    """Chroma-CLOUD-admin-keyed (not Voyage): provisions databases on the
+    RETIRING backend (RDR-155 — Chroma is migration-source-only; P4b
+    deletes this path and this test with it). Post-migration the Chroma
+    key's admin scope is legitimately gone, so absent creds OR a
+    permission-denied admin call are expected states, not regressions —
+    skip with reason rather than fail a gate on a backend on its way out."""
+    import os  # noqa: PLC0415 — file pattern: deferred imports
+
+    from chromadb.errors import ChromaError  # noqa: PLC0415 — file pattern: deferred imports
+
+    from nexus.commands._provision import _cloud_admin_client, ensure_databases  # noqa: PLC0415 — file pattern: deferred imports
 
     api_key = os.environ.get("CHROMA_API_KEY", "")
     database = os.environ.get("CHROMA_DATABASE", "")
-    admin = _cloud_admin_client(api_key)
-    first = ensure_databases(admin, base=database)
-    second = ensure_databases(admin, base=database)
+    if not (api_key and database):
+        pytest.skip("no Chroma Cloud admin credentials (retiring backend)")
+    try:
+        admin = _cloud_admin_client(api_key)
+        first = ensure_databases(admin, base=database)
+        second = ensure_databases(admin, base=database)
+    except ChromaError as exc:
+        if "permission" in str(exc).lower():
+            pytest.skip(
+                "Chroma Cloud key lacks admin scope (expected post-migration; "
+                "RDR-155 P4b removes this path)"
+            )
+        raise
     assert set(first.keys()) == {database}
     assert all(not v for v in second.values())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -244,9 +244,15 @@ def test_t3_store_put_and_list_roundtrip(runner):
 def test_t3_store_put_search_roundtrip(runner):
     uid = _uid("search")
     _store_put(runner, uid)
+    # --no-threshold: the uid needle is a random hex suffix, so its
+    # embedding distance wobbles right at the knowledge-corpus threshold
+    # (observed live 2026-07-14: threshold 0.650, top_distance 0.657 —
+    # dropped with the nexus-uro6c diagnostic, flaking the gate). This
+    # test pins the STORE->SEARCH ROUNDTRIP, not default threshold
+    # policy; the where-filter already pins exactness.
     result = runner.invoke(main, [
         "search", uid, "--corpus", _T3_COL, "--n", "5",
-        "--where", f"title={uid}.md",
+        "--where", f"title={uid}.md", "--no-threshold",
     ])
     assert result.exit_code == 0 and uid in result.output
 

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "6.7.0"
+version = "6.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## conexus 6.7.1

Bugfix release — every fix found by live post-release dogfooding of 6.7.0 against a real service-mode install.

- **Metadata-filtered search fixed in service mode**: the `where=` path (incl. the 6.7.0 range operators) crashed on the raising `_db` sentinel; the catalog prefilter now falls through as its contract claimed.
- **`nx catalog reconcile` usable at scale**: batched per-collection `$in` fetches + progress emission — 21k-doc catalog heals in ~4 min (was 1h42m and unfinished). Summary splits real chunks-LOST gaps from expected never-chunked entries.
- **Re-index repairs manifest-less docs**: owner-scoped manifest self-heal inside `nx index repo` (after indexing, before GC) — the permanent-skip ghost class closes, no re-embedding.
- **Orphan GC mass-delete guard**: refuses sweeps condemning >25% of a collection's decidable chunks (catches the actual 27.9% field incident shape); `NX_GC_FORCE=1` override; per-doc prune logging.
- Local-service gate fully self-provisioning (self-stamped jar, scratch-pinned config, voyage mask knob).

### Gates (all green on this tree)
- Full pytest 13,138 · local-service gate PASSED 475/33 (voyage/CCE subset live)
- `--with-cloud` rehearsal PASSED (cloud→cloud Voyage journey) · sandbox smoke done
- Engine floor gate green (cloud 0.1.41 == floor; no cloud-relevant service drift)

Full details in CHANGELOG.md 6.7.1.