### PR TITLE
release: conexus 6.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v6.7.1"
+        "ref": "v6.8.0"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "6.7.1"
+      "version": "6.8.0"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v6.7.1"
+        "ref": "v6.8.0"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "6.7.1"
+      "version": "6.8.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.8.0] - 2026-07-14
+
+Two user-experience arcs, both born from live dogfooding of the 6.7.x
+releases on a real install.
+
+### Added
+
+- **Chunk quarantine (soft delete).** The orphan GC never hard-deletes
+  directly: orphans MOVE to a per-origin sibling collection
+  (`quarantine-<type>__<owner>__<model>__v<n>`, excluded from every search
+  surface by its prefix), embeddings intact. Re-referenced chunks restore
+  automatically; rows older than `NX_GC_QUARANTINE_DAYS` (default 14)
+  hard-delete on a later pass, and only that expiry step is guarded by the
+  safety floor. The recurring "sweep refused" warning on large git pulls is
+  gone — mass supersede churn quarantines silently and expires quietly.
+  Doctor drift checks, migration ETL, and legacy `nx t3 gc` all treat
+  quarantine collections as expected system state. First concrete piece of
+  the RDR-156 soft-delete theme.
+- **Finish-the-upgrade.** `uv tool upgrade conexus` swaps the disk but
+  every long-lived process keeps executing old code from memory. Now: a
+  `last_seen_version` stamp triggers a safe finish pass on the first
+  invocation after a version change (in `nx`, `nx-mcp`, and
+  `nx-mcp-catalog`), restarting detached daemons (aspect-worker with
+  drain-polling; MinerU via its lifecycle verbs) and naming the processes
+  only you can close (MCP hosts belong to live Claude sessions).
+  `nx daemon restart-stale [--dry-run]` is the manual form; `nx doctor`
+  gains a "Process freshness" check; the uv-receipt source (local checkout
+  / pinned / unpinned) is reported so "Nothing to upgrade" is
+  self-explanatory. Dev-checkout invocations never act on production
+  processes (venv-scoped detection).
+
+### Fixed
+
+- README now surfaces the Claude-assisted diagnostics/recovery feature
+  (RDR-182) — it was documented only in the CLI reference.
+
 ## [6.7.1] - 2026-07-14
 
 Bugfix release: every fix below was found by live post-release dogfooding of

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For the full deployment story across all three surfaces (install, daemon lifecyc
 - **Typed document catalog** — Xanadu-inspired addressing with typed links (`cites`, `implements`, `supersedes`). Walk from a design doc to the code that implements it.
 - **RDR: Research-Design-Review** — write a spec before you code. Captures the problem, research, alternatives, and chosen approach. The corpus is searchable, so prior decisions surface during new design work.
 - **Local-first** — runs entirely on your machine: an on-device bge-768 ONNX embedder over a bundled Postgres 17 + pgvector service that `nx init` provisions for you. Voyage AI (server-side embeddings) is opt-in for the managed-cloud deployment.
+- **Claude-assisted diagnostics & recovery** — when an upgrade or store goes sideways, `nx forensics <topic>` hands your agent a read-only, lint-verified diagnostic playbook (live store counts included once you opt in), and `nx remediate <topic>` releases a guided recovery playbook behind an explicit, audit-recorded consent — default-off, revocable, and your agent executes it with your credentials, never the product acting on its own. The same `forensics`/`remediate` tools are exposed over MCP for in-session use.
 
 ## CLI quick-start
 

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the conexus plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.8.0] - 2026-07-14
+
+Plugin version aligned with conexus 6.8.0. Plugin-relevant: the MCP servers
+now run the finish-the-upgrade version-transition check at startup.
+
 ## [6.7.1] - 2026-07-14
 
 Plugin version aligned with conexus 6.7.1. Plugin-relevant fix: the MCP

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1685,6 +1685,27 @@ For a SQLite T2 daemon that survives reboots independent of Claude Code, use
 own autostart unit (`nx daemon service install --autostart`, or accepting the
 `nx init` prompt) covers reboot-persistence for every tier.
 
+### nx daemon restart-stale
+
+```
+nx daemon restart-stale [--dry-run]
+```
+
+Finish an upgrade: after `uv tool upgrade conexus` the disk holds the new
+version but every long-lived process (MCP hosts, the aspect-worker, MinerU)
+keeps executing the old code from memory. This verb detects every conexus
+process whose start time predates the installed distribution, restarts the
+classes that are safe to cycle (aspect-worker — respawns on demand; MinerU —
+cycled via its own lifecycle verbs), and names the ones only you can close
+(MCP hosts belong to live Claude sessions). It also reports the install's
+uv-receipt source (local checkout / pinned / PyPI-unpinned), which explains
+why `uv tool upgrade` sometimes reports "Nothing to upgrade".
+
+This runs automatically on the first `nx` invocation after a version change
+(a `last_seen_version` stamp in the config dir), printing one
+`[upgrade-finish]` summary line; the verb is the manual form. `nx doctor`'s
+"Process freshness" check surfaces the same skew.
+
 ### nx daemon t2 start
 
 Start the T2 daemon in the foreground. The daemon IS this Python

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -643,9 +643,9 @@ The summary splits unmatched documents into two classes so real regressions are 
 
 Also see the end-of-run summary on `nx index repo`: a persistent manifest-write failure during indexing is now surfaced there (`WARNING: catalog manifest write failed for N document(s)`) with a pointer to this command.
 
-#### Orphan-GC safety floor (environment knobs)
+#### Orphan-GC quarantine (soft delete)
 
-The `nx index repo` orphan GC refuses a sweep that would delete more than `NX_GC_FLOOR_FRACTION` (default `0.25`) of a collection's decidable chunks when at least 100 chunks are condemned — that shape is almost always a manifest defect (the misclassification class that once deleted 6 live documents), not a real cleanup. The refusal is logged with counts and the verification path (`nx catalog doctor --t3-vs-catalog`, `nx catalog reconcile`). Set `NX_GC_FORCE=1` to override after confirming the chunks are genuinely dead. Every executed prune logs a per-document identity sample.
+The `nx index repo` orphan GC never hard-deletes directly: orphan chunks MOVE to a sibling collection (`quarantine__<owner>__<model>__v<n>`, excluded from every search surface by its prefix), embeddings intact. If a later heal or re-index references a quarantined chunk again, it is restored automatically. Quarantined chunks older than `NX_GC_QUARANTINE_DAYS` (default `14`) are hard-deleted on a later pass — and only THAT expiry step is guarded by the safety floor: a hard-delete condemning more than `NX_GC_FLOOR_FRACTION` (default `0.25`) of the quarantine at 100+ chunks means a manifest defect persisted for the whole grace window (the misclassification class that once deleted 6 live documents) and is refused with the verification path logged (`nx catalog doctor --t3-vs-catalog`, `nx catalog reconcile`); `NX_GC_FORCE=1` overrides after confirming. Ordinary mass updates (a large `git pull` superseding much of a repo) quarantine silently and expire quietly — no warnings, no action needed. Every move logs a per-document identity sample.
 
 ### nx catalog orphans
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "6.7.1"
+version = "6.8.0"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=6.7.1",
+    "conexus[local]>=6.8.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "6.7.1"
+version = "6.8.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/catalog/chunk_quarantine.py
+++ b/src/nexus/catalog/chunk_quarantine.py
@@ -44,15 +44,21 @@ _WRITE_BATCH = 300  # ChromaCloud MAX_RECORDS_PER_WRITE; safe everywhere
 
 
 def quarantine_collection_name(origin: str) -> str:
-    """``code__nexus-1-1__voyage-code-3__v1`` -> its quarantine sibling.
+    """``code__nexus-1-1__voyage-code-3__v1`` -> its quarantine sibling
+    ``quarantine-code__nexus-1-1__voyage-code-3__v1``.
 
-    Swaps the content-type segment for ``quarantine`` — stays a conformant
-    4-part name, and the prefix keeps it out of every search corpus.
+    The origin's content-type stays IN the prefix segment (review 4cb743be
+    C3: dropping it collided every same-owner/model origin onto one
+    sibling, cross-contaminating the expiry floor), so each origin owns a
+    distinct sibling. The ``quarantine-*`` prefix matches no search corpus,
+    which is what keeps quarantined chunks out of every retrieval surface.
+    These names are deliberately outside the strict conformance enum —
+    creation passes ``strict=False`` (system-internal collections).
     """
     parts = origin.split("__", 1)
-    return f"{QUARANTINE_PREFIX}__{parts[1]}" if len(parts) == 2 else (
-        f"{QUARANTINE_PREFIX}__{origin}"
-    )
+    if len(parts) == 2:
+        return f"{QUARANTINE_PREFIX}-{parts[0]}__{parts[1]}"
+    return f"{QUARANTINE_PREFIX}-x__{origin}"
 
 
 def quarantine_days() -> int:
@@ -79,24 +85,63 @@ def _fetch_full(db: Any, col: Any, collection_name: str, ids: list[str]):
     not carry them on ``get`` — its client exposes ``get_embeddings``.
     """
     got = col.get(ids=ids, include=["metadatas", "documents", "embeddings"])
+    got_ids = got["ids"]
     embs = got.get("embeddings")
     if embs is None or (hasattr(embs, "__len__") and len(embs) == 0):
-        client = getattr(db, "_vector_client", None) or getattr(db, "client", None)
-        if client is not None and hasattr(client, "get_embeddings"):
-            embs = client.get_embeddings(collection_name, got["ids"])
-    return got["ids"], embs, got.get("metadatas") or [], got.get("documents") or []
+        # Service mode: the collection stub carries no embeddings on get;
+        # both T3Database and HttpVectorClient expose get_embeddings
+        # directly (review 4cb743be H1 — the old fallback probed
+        # attributes that never existed and was permanently dead).
+        if hasattr(db, "get_embeddings"):
+            embs = db.get_embeddings(collection_name, got_ids)
+    # Alignment guard (review 4cb743be H2): get_embeddings DROPS ids the
+    # store lacks — positional zip against a shorter array would attach
+    # WRONG embeddings to every subsequent id (silent corruption). A
+    # mismatched batch moves without embeddings instead (or fails loud at
+    # the service upsert, which requires them — either way, never mixed).
+    if embs is not None and hasattr(embs, "__len__") and len(embs) != len(got_ids):
+        _log.warning(
+            "quarantine_embeddings_misaligned",
+            collection=collection_name, ids=len(got_ids), embeddings=len(embs),
+        )
+        embs = None
+    return got_ids, embs, got.get("metadatas") or [], got.get("documents") or []
 
 
 def _upsert_full(db: Any, name: str, ids, embeddings, metadatas, documents) -> None:
-    qcol = db.get_or_create_collection(name)
+    # Review 4cb743be C2: the service-mode collection stub has NO upsert —
+    # writes go through db.upsert_chunks_with_embeddings (the ETL-proven
+    # path, embeddings required). Local mode uses the chroma handle, created
+    # strict=False (quarantine names are deliberately non-conformant, C1).
+    service_upsert = getattr(db, "upsert_chunks_with_embeddings", None)
+    qcol = None
+    if service_upsert is None:
+        try:
+            qcol = db.get_or_create_collection(name, strict=False)
+        except TypeError:  # test shims without the strict kwarg
+            qcol = db.get_or_create_collection(name)
     for i in range(0, len(ids), _WRITE_BATCH):
         sl = slice(i, i + _WRITE_BATCH)
-        qcol.upsert(
-            ids=ids[sl],
-            embeddings=embeddings[sl] if embeddings is not None else None,
-            metadatas=metadatas[sl],
-            documents=documents[sl],
-        )
+        if service_upsert is not None:
+            if embeddings is None:
+                raise RuntimeError(
+                    "service-mode quarantine move requires embeddings "
+                    "(upsert_chunks_with_embeddings contract); batch kept "
+                    "in place for retry"
+                )
+            service_upsert(
+                name, ids=list(ids[sl]),
+                documents=list(documents[sl]),
+                embeddings=[list(e) for e in embeddings[sl]],
+                metadatas=list(metadatas[sl]),
+            )
+        else:
+            qcol.upsert(
+                ids=ids[sl],
+                embeddings=embeddings[sl] if embeddings is not None else None,
+                metadatas=metadatas[sl],
+                documents=documents[sl],
+            )
 
 
 def quarantine_orphans(
@@ -164,7 +209,6 @@ def restore_rereferenced(
     if not back_ids:
         return 0
     restored = 0
-    origin = db.get_or_create_collection(collection_name)
     for i in range(0, len(back_ids), _WRITE_BATCH):
         batch = back_ids[i:i + _WRITE_BATCH]
         try:
@@ -217,13 +261,21 @@ def expire_quarantine(
         return 0, 0
     cutoff = datetime.now(UTC) - timedelta(days=quarantine_days())
     cutoff_s = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Review 4cb743be C3: filter to THIS origin's rows — legacy shared
+    # siblings (pre-fix names) may hold multiple origins, and the floor's
+    # fraction must never be computed across unrelated populations.
+    mine = [
+        (cid, m) for cid, m in zip(all_ids, rows.get("metadatas") or [])
+        if (m or {}).get("origin_collection", collection_name) == collection_name
+    ]
+    _FAR_FUTURE = "9999-12-31T23:59:59Z"
     expired_ids = [
-        cid for cid, m in zip(all_ids, rows.get("metadatas") or [])
-        if (m or {}).get("quarantined_at", "9999") <= cutoff_s
+        cid for cid, m in mine
+        if (m or {}).get("quarantined_at", _FAR_FUTURE) <= cutoff_s
     ]
     if not expired_ids:
         return 0, 0
-    frac = len(expired_ids) / len(all_ids) if all_ids else 0.0
+    frac = len(expired_ids) / len(mine) if mine else 0.0
     if (
         len(expired_ids) >= floor_min_chunks
         and frac > floor_fraction
@@ -232,7 +284,7 @@ def expire_quarantine(
         _log.warning(
             "gc_quarantine_expiry_floor_refused",
             collection=collection_name, expiring=len(expired_ids),
-            quarantined=len(all_ids), fraction=round(frac, 3),
+            quarantined=len(mine), fraction=round(frac, 3),
             note=(
                 "a mass hard-delete surviving the full grace window means a "
                 "manifest defect persisted for weeks — verify with "

--- a/src/nexus/catalog/chunk_quarantine.py
+++ b/src/nexus/catalog/chunk_quarantine.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Chunk quarantine — soft delete for the orphan GC (nexus-xukbj).
+
+Instead of hard-deleting orphan chunks (or refusing over-floor sweeps with
+a recurring warning — the nexus-mr89x nag), the GC MOVES orphans to a
+sibling collection named ``quarantine__<owner>__<model>__v<n>``. The
+``quarantine`` prefix is in NO search corpus, so quarantined chunks are
+excluded from every retrieval surface by construction — no filters, no
+metadata-update primitive, no schema change.
+
+Lifecycle per GC pass (wired in ``indexer._prune_deleted_files``):
+
+1. **Restore** — quarantined chashes that are referenced by the manifest
+   again (a heal re-referenced them, or content returned) copy back to the
+   origin collection and leave quarantine. Chash-keyed upsert = idempotent.
+2. **Quarantine** — this pass's orphans move over with their embeddings
+   (no re-embed), stamped ``quarantined_at`` + ``origin_collection`` at add
+   time. NO safety floor here: the move is recoverable, so mass supersede
+   churn from a big ``git pull`` proceeds silently instead of warning
+   forever (the nexus-mr89x refusal nag this module retires).
+3. **Expire** — quarantine rows older than ``NX_GC_QUARANTINE_DAYS``
+   (default 14) hard-delete. The mr89x safety floor applies HERE only: a
+   mass hard-delete surviving a full grace window means a manifest defect
+   persisted for weeks — the one case that should still be loud.
+
+First concrete piece of the RDR-156 soft-delete theme (nexus-70r3c).
+"""
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+QUARANTINE_PREFIX = "quarantine"
+
+#: Days a quarantined chunk survives before the expiry pass hard-deletes it.
+QUARANTINE_DAYS_DEFAULT = 14
+
+_WRITE_BATCH = 300  # ChromaCloud MAX_RECORDS_PER_WRITE; safe everywhere
+
+
+def quarantine_collection_name(origin: str) -> str:
+    """``code__nexus-1-1__voyage-code-3__v1`` -> its quarantine sibling.
+
+    Swaps the content-type segment for ``quarantine`` — stays a conformant
+    4-part name, and the prefix keeps it out of every search corpus.
+    """
+    parts = origin.split("__", 1)
+    return f"{QUARANTINE_PREFIX}__{parts[1]}" if len(parts) == 2 else (
+        f"{QUARANTINE_PREFIX}__{origin}"
+    )
+
+
+def quarantine_days() -> int:
+    raw = os.environ.get("NX_GC_QUARANTINE_DAYS", "")
+    if not raw:
+        return QUARANTINE_DAYS_DEFAULT
+    try:
+        val = int(raw)
+    except ValueError:
+        val = -1
+    if val < 0:
+        _log.warning(
+            "gc_quarantine_days_invalid",
+            raw=raw, using=QUARANTINE_DAYS_DEFAULT,
+        )
+        return QUARANTINE_DAYS_DEFAULT
+    return val
+
+
+def _fetch_full(db: Any, col: Any, collection_name: str, ids: list[str]):
+    """(ids, embeddings, metadatas, documents) for *ids*, both modes.
+
+    Local Chroma returns embeddings on ``include``; the service stub does
+    not carry them on ``get`` — its client exposes ``get_embeddings``.
+    """
+    got = col.get(ids=ids, include=["metadatas", "documents", "embeddings"])
+    embs = got.get("embeddings")
+    if embs is None or (hasattr(embs, "__len__") and len(embs) == 0):
+        client = getattr(db, "_vector_client", None) or getattr(db, "client", None)
+        if client is not None and hasattr(client, "get_embeddings"):
+            embs = client.get_embeddings(collection_name, got["ids"])
+    return got["ids"], embs, got.get("metadatas") or [], got.get("documents") or []
+
+
+def _upsert_full(db: Any, name: str, ids, embeddings, metadatas, documents) -> None:
+    qcol = db.get_or_create_collection(name)
+    for i in range(0, len(ids), _WRITE_BATCH):
+        sl = slice(i, i + _WRITE_BATCH)
+        qcol.upsert(
+            ids=ids[sl],
+            embeddings=embeddings[sl] if embeddings is not None else None,
+            metadatas=metadatas[sl],
+            documents=documents[sl],
+        )
+
+
+def quarantine_orphans(
+    db: Any,
+    col: Any,
+    collection_name: str,
+    orphan_ids: list[str],
+    metadatas_by_id: dict[str, dict] | None = None,
+) -> int:
+    """Move *orphan_ids* from *col* into the quarantine sibling.
+
+    Returns the number of chunks quarantined. Failure to move leaves the
+    chunks in place (never delete-before-copy) and logs — the next pass
+    retries.
+    """
+    if not orphan_ids:
+        return 0
+    qname = quarantine_collection_name(collection_name)
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    moved = 0
+    for i in range(0, len(orphan_ids), _WRITE_BATCH):
+        batch = orphan_ids[i:i + _WRITE_BATCH]
+        try:
+            ids, embs, metas, docs = _fetch_full(db, col, collection_name, batch)
+            stamped = []
+            for m in metas:
+                m = dict(m or {})
+                m["quarantined_at"] = now
+                m["origin_collection"] = collection_name
+                stamped.append(m)
+            _upsert_full(db, qname, ids, embs, stamped, docs)
+            col.delete(ids=ids)  # copy-then-delete: never lossy
+            moved += len(ids)
+        except Exception as exc:  # noqa: BLE001 — boundary catch; a failed batch stays in place and retries next pass
+            _log.warning(
+                "gc_quarantine_move_failed",
+                collection=collection_name, batch=len(batch), error=str(exc),
+            )
+    if moved:
+        _log.info(
+            "gc_quarantined_orphans",
+            collection=collection_name, quarantine=qname, count=moved,
+        )
+    return moved
+
+
+def restore_rereferenced(
+    db: Any, collection_name: str, referenced: set[str],
+) -> int:
+    """Copy quarantined chunks whose chash is referenced again back to the
+    origin collection; returns the number restored."""
+    qname = quarantine_collection_name(collection_name)
+    try:
+        qcol = db.get_collection(qname)
+    except Exception:  # noqa: BLE001 — no quarantine sibling yet = nothing to restore
+        return 0
+    from nexus.indexer import _paginated_get  # noqa: PLC0415 — deferred: heavy module, circular-dep avoidance
+
+    rows = _paginated_get(qcol, include=["metadatas"])
+    back_ids = [
+        cid for cid, m in zip(rows.get("ids") or [], rows.get("metadatas") or [])
+        if ((m or {}).get("chunk_text_hash") or cid)[:32] in referenced
+        and (m or {}).get("origin_collection", collection_name) == collection_name
+    ]
+    if not back_ids:
+        return 0
+    restored = 0
+    origin = db.get_or_create_collection(collection_name)
+    for i in range(0, len(back_ids), _WRITE_BATCH):
+        batch = back_ids[i:i + _WRITE_BATCH]
+        try:
+            ids, embs, metas, docs = _fetch_full(db, qcol, qname, batch)
+            cleaned = []
+            for m in metas:
+                m = dict(m or {})
+                m.pop("quarantined_at", None)
+                m.pop("origin_collection", None)
+                cleaned.append(m)
+            _upsert_full(db, collection_name, ids, embs, cleaned, docs)
+            qcol.delete(ids=ids)
+            restored += len(ids)
+        except Exception as exc:  # noqa: BLE001 — boundary catch; a failed batch stays quarantined and retries next pass
+            _log.warning(
+                "gc_quarantine_restore_failed",
+                collection=collection_name, batch=len(batch), error=str(exc),
+            )
+    if restored:
+        _log.info(
+            "gc_restored_from_quarantine",
+            collection=collection_name, count=restored,
+        )
+    return restored
+
+
+def expire_quarantine(
+    db: Any,
+    collection_name: str,
+    *,
+    floor_fraction: float,
+    floor_min_chunks: int,
+) -> tuple[int, int]:
+    """Hard-delete quarantine rows older than the grace window.
+
+    Returns ``(expired, refused)``. The mr89x safety floor applies here —
+    a mass hard-delete after a FULL grace window means a manifest defect
+    persisted for weeks, the one case that should still be loud.
+    """
+    qname = quarantine_collection_name(collection_name)
+    try:
+        qcol = db.get_collection(qname)
+    except Exception:  # noqa: BLE001 — no quarantine sibling = nothing to expire
+        return 0, 0
+    from nexus.indexer import _batched_delete, _paginated_get  # noqa: PLC0415 — deferred: heavy module, circular-dep avoidance
+
+    rows = _paginated_get(qcol, include=["metadatas"])
+    all_ids = rows.get("ids") or []
+    if not all_ids:
+        return 0, 0
+    cutoff = datetime.now(UTC) - timedelta(days=quarantine_days())
+    cutoff_s = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+    expired_ids = [
+        cid for cid, m in zip(all_ids, rows.get("metadatas") or [])
+        if (m or {}).get("quarantined_at", "9999") <= cutoff_s
+    ]
+    if not expired_ids:
+        return 0, 0
+    frac = len(expired_ids) / len(all_ids) if all_ids else 0.0
+    if (
+        len(expired_ids) >= floor_min_chunks
+        and frac > floor_fraction
+        and os.environ.get("NX_GC_FORCE", "") != "1"
+    ):
+        _log.warning(
+            "gc_quarantine_expiry_floor_refused",
+            collection=collection_name, expiring=len(expired_ids),
+            quarantined=len(all_ids), fraction=round(frac, 3),
+            note=(
+                "a mass hard-delete surviving the full grace window means a "
+                "manifest defect persisted for weeks — verify with "
+                "`nx catalog doctor --t3-vs-catalog` + `nx catalog "
+                "reconcile`; override with NX_GC_FORCE=1."
+            ),
+        )
+        return 0, len(expired_ids)
+    _batched_delete(qcol, expired_ids)
+    _log.info(
+        "gc_quarantine_expired",
+        collection=collection_name, count=len(expired_ids),
+    )
+    return len(expired_ids), 0

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -95,6 +95,21 @@ def main(ctx: click.Context, verbose: bool) -> None:
     from nexus.commands._migration_prompt import maybe_emit_bootstrap_prompt  # noqa: PLC0415 — circular-dep avoidance: deferred intra-package import
     maybe_emit_bootstrap_prompt()
 
+    # nexus-4xgfy: finish-the-upgrade auto-trigger. uv offers no
+    # post-install hook, so the first invocation after a version change
+    # runs the safe finish pass (restart detached stale daemons; name the
+    # session-bound ones) and says so in one line. Same-version runs are a
+    # single stat() — effectively free.
+    try:
+        from nexus.config import nexus_config_dir  # noqa: PLC0415 — deferred import
+        from nexus.upgrade_finish import check_version_transition  # noqa: PLC0415 — deferred import
+
+        _summary = check_version_transition(nexus_config_dir())
+        if _summary:
+            click.echo(f"[upgrade-finish] {_summary}", err=True)
+    except Exception:  # noqa: BLE001 — the trigger must never break CLI startup
+        pass
+
 
 main.add_command(catalog)
 main.add_command(collection)

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -108,7 +108,10 @@ def main(ctx: click.Context, verbose: bool) -> None:
         if _summary:
             click.echo(f"[upgrade-finish] {_summary}", err=True)
     except Exception:  # noqa: BLE001 — the trigger must never break CLI startup
-        pass
+        import structlog  # noqa: PLC0415 — deferred import
+        structlog.get_logger(__name__).warning(
+            "upgrade_finish_trigger_failed", exc_info=True,
+        )
 
 
 main.add_command(catalog)

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -2352,3 +2352,32 @@ def aspect_worker_start_cmd(
         config_dir=config_dir, tenant=tenant,
         stale_timeout_seconds=stale_timeout_seconds,
     )
+
+
+@daemon_group.command("restart-stale")
+@click.option("--dry-run", is_flag=True, default=False,
+              help="Report what would be restarted without touching anything.")
+def restart_stale_cmd(dry_run: bool) -> None:
+    """Finish an upgrade: restart processes still running old code.
+
+    After ``uv tool upgrade conexus`` the disk is new but every long-lived
+    process (MCP hosts, aspect-worker, MinerU) keeps executing the old
+    code from memory (nexus-4xgfy). This verb restarts the classes that
+    are safe to cycle and names the ones only you can close (MCP hosts
+    belong to live Claude sessions). Runs automatically on the first
+    ``nx`` invocation after a version change; this is the manual form.
+    """
+    from nexus.upgrade_finish import (  # noqa: PLC0415 — deferred import
+        detect_stale_processes,
+        install_source,
+        restart_stale,
+    )
+
+    report = detect_stale_processes()
+    click.echo(f"installed: conexus {report.installed_version}  "
+               f"(source: {install_source()})")
+    if not report.stale:
+        click.echo("no stale processes — the machine matches the disk.")
+        return
+    for line in restart_stale(report, dry_run=dry_run):
+        click.echo(f"  {line}")

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -205,7 +205,13 @@ def prune_stale_cmd(collection: str, dry_run: bool, confirm: bool) -> None:
         except Exception as exc:  # noqa: BLE001 — boundary catch; logged then re-raised as a domain error
             click.echo(f"Failed to list collections: {exc}")
             raise click.exceptions.Exit(1)
-        target_collections = [c["name"] for c in all_colls]
+        # nexus-xukbj: quarantine siblings are managed by the GC's own
+        # grace-window expiry (with its safety floor) — the legacy sweep
+        # must never hard-delete them out-of-band.
+        target_collections = [
+            c["name"] for c in all_colls
+            if not c["name"].startswith("quarantine-")
+        ]
 
     if not target_collections:
         click.echo("No collections to scan.")

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -148,7 +148,13 @@ def _normalize_for_write(metadata: dict, collection_name: str) -> dict:
 # bypass by calling ``coll.upsert()`` directly; this set keeps the
 # T3-public write path symmetric so .nxexp round-trips don't silently
 # strip the collection's metadata at import time.
-_BYPASS_SCHEMA_PREFIXES: tuple[str, ...] = ("taxonomy__",)
+_BYPASS_SCHEMA_PREFIXES: tuple[str, ...] = (
+    "taxonomy__",
+    # nexus-xukbj: quarantine siblings (quarantine-<type>__...) are
+    # system-internal, deliberately non-conformant and catalog-unregistered
+    # — the drift/doctor checks must treat them as expected state.
+    "quarantine-",
+)
 
 
 def _bypass_canonical_schema(collection_name: str) -> bool:

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -134,6 +134,50 @@ def _check_python() -> list[HealthResult]:
     return [r]
 
 
+def _check_process_skew() -> list[HealthResult]:
+    """nexus-4xgfy: the disk can be upgraded while every running process
+    still executes the old code from memory — three live incidents
+    (6.7.0/6.7.1 upgrades) where doctor said 'latest' and the whole
+    machine was stale. Enumerate running conexus processes, compare their
+    start times against the installed distribution's mtime, and WARN with
+    the per-process remedy. Also names the install's uv-receipt source so
+    'uv tool upgrade did nothing' is self-explanatory.
+    """
+    try:
+        from nexus.upgrade_finish import (  # noqa: PLC0415 — deferred import
+            detect_stale_processes,
+            install_source,
+        )
+
+        report = detect_stale_processes()
+    except Exception:  # noqa: BLE001 — probe failure must not fail doctor; skip silently
+        return []
+    if not report.stale:
+        return [HealthResult(
+            label="Process freshness",
+            ok=True,
+            detail=(
+                f"all running conexus processes match the installed "
+                f"{report.installed_version} (install source: "
+                f"{install_source().split(' — ')[0]})"
+            ),
+        )]
+    names = ", ".join(
+        f"{p.kind} pid {p.pid}" for p in report.stale[:6]
+    )
+    return [HealthResult(
+        label="Process freshness",
+        ok=False,
+        warn=True,
+        detail=(
+            f"{len(report.stale)} process(es) predate the installed "
+            f"{report.installed_version} and are running OLD code: {names}. "
+            "Run `nx daemon restart-stale` (restarts what is safe; names "
+            "the Claude sessions only you can close)."
+        ),
+    )]
+
+
 def _check_cli_version() -> list[HealthResult]:
     """Check whether a newer conexus version is available on PyPI."""
     try:
@@ -2701,6 +2745,7 @@ def run_health_checks() -> tuple[list[HealthResult], bool]:
 
     results.extend(_check_python())
     results.extend(_check_cli_version())
+    results.extend(_check_process_skew())
     results.extend(_check_plugin_name())
     results.extend(_check_credential_persistence())
 

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -2375,6 +2375,17 @@ def _prune_deleted_files(
             col = db.get_collection(collection_name)
         except _ChromaNotFoundError:
             continue
+        # nexus-xukbj: restore BEFORE the empty-collection early-continue —
+        # a fully-quarantined collection (origin emptied) must still be able
+        # to restore when a heal re-references its chashes.
+        from nexus.catalog.chunk_quarantine import restore_rereferenced  # noqa: PLC0415 — deferred import
+        try:
+            restored = restore_rereferenced(db, collection_name, referenced)
+        except Exception:  # noqa: BLE001 — best-effort; failure logged, pass continues
+            _log.warning("gc_restore_pass_failed", collection=collection_name,
+                         exc_info=True)
+            restored = 0
+
         all_chunks = _paginated_get(col, include=["metadatas"])
         if not all_chunks["ids"]:
             continue
@@ -2432,56 +2443,37 @@ def _prune_deleted_files(
                          note=("re-index source or run `nx t3 reidentify` "
                                "to populate chunk_text_hash; until then GC "
                                "cannot decide these chunks safely"))
+        # nexus-xukbj (soft delete, supersedes the per-sweep mr89x floor):
+        # restore first (a heal may have re-referenced quarantined chashes),
+        # then QUARANTINE this pass's orphans (recoverable move — no floor,
+        # no warning: mass supersede churn from a big git pull proceeds
+        # silently), then EXPIRE rows older than the grace window (the
+        # mr89x floor lives THERE — the one still-loud case is a manifest
+        # defect that persisted for weeks).
+        from nexus.catalog.chunk_quarantine import (  # noqa: PLC0415 — deferred import
+            expire_quarantine,
+            quarantine_orphans,
+        )
+
         if orphan_ids:
-            # nexus-mr89x (a): partial-gap safety floor — the sibling of the
-            # manifest-EMPTY guard above for the manifest-PARTIAL case. A
-            # collection-name stamp mismatch (the nexus-x6kdz class) or a
-            # mass manifest drop classifies ~ALL chunks as orphans; deleting
-            # them is unrecoverable data loss (the 2026-07-09 field incident
-            # pruned 6 live RDR docs). Refuse mass deletion: above the floor
-            # the sweep is far more likely a manifest defect than a real
-            # cleanup, and the c21fk self-heal pass has ALREADY run before
-            # this GC — a surviving mass-orphan verdict is deeply suspect.
-            # Legitimate large cleanups stay under the floor or use the
-            # explicit override.
-            # Denominator = DECIDABLE chunks only (review e2423e3b F4): a
-            # collection dominated by undecidable no-chash relics must not
-            # dilute the fraction below the floor while ~all of its
-            # decidable population is condemned.
             decidable = len(all_chunks["ids"]) - unsafe_skipped
             frac = len(orphan_ids) / decidable if decidable else 0.0
-            floor_frac = _gc_floor_fraction()
-            if (
-                len(orphan_ids) >= _GC_FLOOR_MIN_CHUNKS
-                and frac > floor_frac
-                and os.environ.get("NX_GC_FORCE", "") != "1"
-            ):
-                _log.warning(
-                    "gc_safety_floor_refused",
-                    collection=collection_name,
-                    orphans=len(orphan_ids), decidable=decidable,
-                    fraction=round(frac, 3), floor=floor_frac,
-                    note=(
-                        "refusing to prune: orphan fraction exceeds the "
-                        "safety floor — this is the manifest-gap "
-                        "misclassification shape (nexus-mr89x), not a "
-                        "normal cleanup. Verify with `nx catalog doctor "
-                        "--t3-vs-catalog` and `nx catalog reconcile`; "
-                        "override with NX_GC_FORCE=1 only after confirming "
-                        "the chunks are genuinely dead."
-                    ),
-                )
-                continue
-            # nexus-mr89x (b): per-doc visibility. The field incident gave
-            # zero per-doc signal — the operator reverse-engineered the 6
-            # pruned docs from a set difference. The bounded identity sample
-            # was captured inline during classification (review e2423e3b F5).
-            _batched_delete(col, orphan_ids)
+            quarantined = quarantine_orphans(
+                db, col, collection_name, orphan_ids,
+            )
             _log.info("pruned orphan chunks",
-                      collection=collection_name, count=len(orphan_ids),
-                      fraction=round(frac, 3), sample=orphan_sample)
-            _log.debug("pruned_orphan_chunk_ids",
-                       collection=collection_name, ids=orphan_ids)
+                      collection=collection_name, count=quarantined,
+                      fraction=round(frac, 3), restored=restored,
+                      sample=orphan_sample, mode="quarantine")
+        try:
+            expire_quarantine(
+                db, collection_name,
+                floor_fraction=_gc_floor_fraction(),
+                floor_min_chunks=_GC_FLOOR_MIN_CHUNKS,
+            )
+        except Exception:  # noqa: BLE001 — best-effort; failure logged, pass continues
+            _log.warning("gc_expiry_pass_failed", collection=collection_name,
+                         exc_info=True)
 
 
 # ── Main indexing pipeline ───────────────────────────────────────────────────

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -690,6 +690,23 @@ def catalog_link_bulk(
 
 
 def main():
+    # nexus-4xgfy (critique 38b7db3d C1): the dominant post-upgrade path is
+    # a Claude session spawning THIS process with no bare `nx` invocation in
+    # between — the finish trigger must fire here too. Report-safe: the MCP
+    # host never kills anything from its own startup; the transition stamp +
+    # safe restarts are handled identically to the CLI trigger.
+    try:
+        from nexus.config import nexus_config_dir  # noqa: PLC0415 — deferred import
+        from nexus.upgrade_finish import check_version_transition  # noqa: PLC0415 — deferred import
+
+        _summary = check_version_transition(nexus_config_dir())
+        if _summary:
+            import structlog as _sl  # noqa: PLC0415 — deferred import
+
+            _sl.get_logger(__name__).info("upgrade_finish", summary=_summary)
+    except Exception:  # noqa: BLE001 — the trigger must never break server startup
+        pass
+
     """Run the catalog MCP server on stdio transport.
 
     Lifecycle logging: emits ``mcp_server_starting``,

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -6408,6 +6408,23 @@ def _resolve_mode_diagnostics() -> dict[str, str | None]:
 
 
 def main():
+    # nexus-4xgfy (critique 38b7db3d C1): the dominant post-upgrade path is
+    # a Claude session spawning THIS process with no bare `nx` invocation in
+    # between — the finish trigger must fire here too. Report-safe: the MCP
+    # host never kills anything from its own startup; the transition stamp +
+    # safe restarts are handled identically to the CLI trigger.
+    try:
+        from nexus.config import nexus_config_dir  # noqa: PLC0415 — deferred import
+        from nexus.upgrade_finish import check_version_transition  # noqa: PLC0415 — deferred import
+
+        _summary = check_version_transition(nexus_config_dir())
+        if _summary:
+            import structlog as _sl  # noqa: PLC0415 — deferred import
+
+            _sl.get_logger(__name__).info("upgrade_finish", summary=_summary)
+    except Exception:  # noqa: BLE001 — the trigger must never break server startup
+        pass
+
     """Run the core MCP server on stdio transport.
 
     Lifecycle logging: emits ``mcp_server_starting``,

--- a/src/nexus/migration/vector_etl.py
+++ b/src/nexus/migration/vector_etl.py
@@ -134,7 +134,12 @@ MigrationStatus = Literal[
 
 #: Collection-name prefixes excluded from DEFAULT enumeration (explicit
 #: --collections naming overrides). Session-ephemeral, die-with-Chroma data.
-EPHEMERAL_EXCLUDE_PREFIXES: tuple[str, ...] = ("tuples__",)
+EPHEMERAL_EXCLUDE_PREFIXES: tuple[str, ...] = (
+    "tuples__",
+    # nexus-xukbj: quarantine siblings hold soft-deleted orphans awaiting
+    # expiry — never worth migrating as first-class data.
+    "quarantine-",
+)
 
 #: Nonconformant collection names known to hold DERIVED data — recomputable
 #: from a durable source, so their absence from pgvector is not data loss.

--- a/src/nexus/upgrade_finish.py
+++ b/src/nexus/upgrade_finish.py
@@ -37,8 +37,29 @@ import structlog
 
 _log = structlog.get_logger(__name__)
 
-#: Marker substrings identifying conexus processes in `ps` output.
+#: Fallback marker substrings identifying conexus processes in `ps`
+#: output. The AUTHORITATIVE marker is derived per-call from the running
+#: distribution's actual install root (critique 38b7db3d: a hardcoded
+#: production-only literal both fails open on custom install layouts and
+#: let a dev-checkout invocation measure PRODUCTION processes against the
+#: dev venv's mtime — the cross-venv confusion that could SIGTERM a live
+#: worker from an unrelated dev command).
 _PROC_MARKERS = ("uv/tools/conexus", ".local/bin/nx")
+
+
+def _install_root() -> Path:
+    """Site-packages root of the RUNNING conexus distribution."""
+    import importlib.metadata as md  # noqa: PLC0415 — stdlib, deferred
+
+    return Path(str(md.distribution("conexus").locate_file("")))
+
+
+def running_from_tool_install() -> bool:
+    """True when this interpreter IS the uv tool install (vs a dev
+    checkout venv). The restart pass only ever acts from the tool
+    install — a dev venv's mtime says nothing about production
+    processes and must never kill them."""
+    return "uv/tools/conexus" in str(_install_root())
 
 #: Filename of the version stamp inside the nexus config dir.
 STAMP_FILENAME = "last_seen_version"
@@ -143,12 +164,18 @@ def enumerate_processes(ps_output: str | None = None) -> list[tuple[int, int, st
         ps_output = proc.stdout
     out: list[tuple[int, int, str]] = []
     me = os.getpid()
+    try:
+        # site-packages -> lib/pythonX.Y -> lib -> THE VENV ROOT: the one
+        # path every process launched from this install carries.
+        markers: tuple[str, ...] = (str(_install_root().parents[2]),)
+    except Exception:  # noqa: BLE001 — metadata unavailable: fall back to the conventional layout
+        markers = _PROC_MARKERS
     for line in ps_output.splitlines()[1:]:
         m = re.match(r"\s*(\d+)\s+(\S+)\s+(.*)", line)
         if not m:
             continue
         pid, etime, command = int(m.group(1)), m.group(2), m.group(3)
-        if pid == me or not any(k in command for k in _PROC_MARKERS):
+        if pid == me or not any(k in command for k in markers):
             continue
         try:
             age = _parse_etime(etime)
@@ -211,10 +238,32 @@ def restart_stale(report: SkewReport, *, dry_run: bool = False) -> list[str]:
                 import signal as _signal  # noqa: PLC0415 — stdlib, deferred
 
                 os.kill(proc.pid, _signal.SIGTERM)
-                actions.append(
-                    f"restarted {proc.kind} (pid {proc.pid} stopped; "
-                    "respawns on demand)"
-                )
+                # Critique 38b7db3d C3: the worker's graceful drain is
+                # bounded at 10s while an in-flight claude -p child can run
+                # far longer, and PDEATHSIG is inactive on macOS (the RF8
+                # orphan gap). Poll for ACTUAL exit past the drain window;
+                # never SIGKILL (that is what orphans the child), and never
+                # claim success we did not observe.
+                deadline = time.time() + 12
+                exited = False
+                while time.time() < deadline:
+                    try:
+                        os.kill(proc.pid, 0)
+                    except ProcessLookupError:
+                        exited = True
+                        break
+                    time.sleep(0.5)
+                if exited:
+                    actions.append(
+                        f"restarted {proc.kind} (pid {proc.pid} drained; "
+                        "respawns on demand)"
+                    )
+                else:
+                    actions.append(
+                        f"{proc.kind} pid {proc.pid}: SIGTERM sent but still "
+                        "draining (likely an in-flight extraction) — left "
+                        "running; re-check with `nx doctor`"
+                    )
             except (ProcessLookupError, PermissionError) as exc:
                 actions.append(f"{proc.kind} pid {proc.pid}: {exc}")
         elif proc.kind == "mineru":
@@ -227,11 +276,19 @@ def restart_stale(report: SkewReport, *, dry_run: bool = False) -> list[str]:
             except Exception as exc:  # noqa: BLE001 — best-effort cycle; failure surfaced in the action line
                 actions.append(f"mineru cycle failed: {exc}")
     for proc in report.session_bound:
-        actions.append(
-            f"NEEDS HUMAN: {proc.kind} (pid {proc.pid}) belongs to a live "
-            "Claude session — exit that session to pick up "
-            f"{report.installed_version}"
-        )
+        if proc.kind == "mcp-host":
+            remedy = (
+                "belongs to a live Claude session — exit that session to "
+                f"pick up {report.installed_version}"
+            )
+        elif proc.kind == "service":
+            remedy = (
+                "is the storage service — cycle it via its own lifecycle "
+                "(`nx daemon service stop` / next use respawns it)"
+            )
+        else:
+            remedy = f"predates {report.installed_version}; restart it manually"
+        actions.append(f"NEEDS HUMAN: {proc.kind} (pid {proc.pid}) {remedy}")
     return actions
 
 
@@ -312,6 +369,11 @@ def check_version_transition(config_dir: Path) -> str | None:
         return None  # unwritable config dir: skip silently, retry next run
     if not seen:
         return None  # first-ever run: nothing stale to finish
+    if not running_from_tool_install():
+        # A dev checkout's venv mtime says nothing about the production
+        # processes on this box — measuring (let alone killing) them from
+        # here is the cross-venv confusion class. Report-only via doctor.
+        return None
     try:
         report = detect_stale_processes()
         actions = restart_stale(report)

--- a/src/nexus/upgrade_finish.py
+++ b/src/nexus/upgrade_finish.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Finish-the-upgrade: process-skew detection + safe restart (nexus-4xgfy).
+
+Three live incidents motivated this module (2026-07-13/14, the 6.7.0 and
+6.7.1 upgrades): after ``uv tool upgrade conexus``, ``nx --version`` and
+``nx doctor`` both reported the new version while EVERY long-lived process
+on the box (MCP hosts, the aspect-worker — twice orphaned to ppid 1 — and
+the MinerU server) kept executing the old code from memory. Nothing
+surfaced the skew and nothing fixed it short of tribal knowledge.
+
+The disk is upgraded; the *machine* is not, until stale processes restart.
+uv offers no post-install hook (no package manager in this class does), so
+the finish choreography triggers from the product side:
+
+- :func:`detect_stale_processes` — every running conexus-venv process whose
+  start time predates the installed distribution's mtime is executing old
+  code. Feeds the ``nx doctor`` check and the auto-trigger.
+- :func:`restart_stale` — restarts the classes that are SAFE to cycle
+  (detached daemons: aspect-worker, MinerU); reports the ones only the
+  human can close (MCP hosts belong to live Claude sessions).
+- :func:`install_source` — reads the uv receipt so "``uv tool upgrade``
+  did nothing" is self-explanatory (directory-tracking vs pinned vs PyPI).
+- The version stamp (:func:`check_version_transition`) — called at CLI
+  startup; on the first invocation after a version change it runs the safe
+  finish pass automatically and prints one summary line.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+#: Marker substrings identifying conexus processes in `ps` output.
+_PROC_MARKERS = ("uv/tools/conexus", ".local/bin/nx")
+
+#: Filename of the version stamp inside the nexus config dir.
+STAMP_FILENAME = "last_seen_version"
+
+
+@dataclass
+class StaleProcess:
+    pid: int
+    kind: str  # "mcp-host" | "aspect-worker" | "mineru" | "service" | "other"
+    command: str
+    age_s: int  # process age in seconds
+
+    @property
+    def restartable(self) -> bool:
+        """Safe to cycle without severing a live human session."""
+        return self.kind in ("aspect-worker", "mineru")
+
+
+@dataclass
+class SkewReport:
+    installed_version: str = ""
+    install_mtime: float = 0.0
+    stale: list[StaleProcess] = field(default_factory=list)
+
+    @property
+    def session_bound(self) -> list[StaleProcess]:
+        return [p for p in self.stale if not p.restartable]
+
+    @property
+    def restartable(self) -> list[StaleProcess]:
+        return [p for p in self.stale if p.restartable]
+
+
+def _classify(command: str) -> str:
+    if "aspect-worker" in command:
+        return "aspect-worker"
+    if "mineru" in command:
+        return "mineru"
+    if "nx-mcp" in command:
+        return "mcp-host"
+    if "daemon service" in command or "nexus-service" in command:
+        return "service"
+    return "other"
+
+
+def _parse_etime(etime: str) -> int:
+    """``[[dd-]hh:]mm:ss`` -> seconds (POSIX ps etime)."""
+    days = 0
+    if "-" in etime:
+        d, etime = etime.split("-", 1)
+        days = int(d)
+    parts = [int(p) for p in etime.split(":")]
+    while len(parts) < 3:
+        parts.insert(0, 0)
+    h, m, s = parts
+    return ((days * 24 + h) * 60 + m) * 60 + s
+
+
+def install_mtime_and_version() -> tuple[float, str]:
+    """(mtime, version) of the installed conexus distribution.
+
+    The dist-info directory's mtime is when the venv last changed — any
+    process started before it is executing old code.
+    """
+    import importlib.metadata as md  # noqa: PLC0415 — stdlib, deferred for startup cost
+
+    dist = md.distribution("conexus")
+    version = dist.version
+    path = getattr(dist, "_path", None)
+    mtime = Path(str(path)).stat().st_mtime if path else 0.0
+    return mtime, version
+
+
+def enumerate_processes(ps_output: str | None = None) -> list[tuple[int, int, str]]:
+    """``[(pid, age_s, command)]`` for every running conexus process.
+
+    ``ps -eo pid,etime,command`` is POSIX-portable (etime, unlike lstart,
+    parses identically on macOS and Linux). Injectable for tests.
+    """
+    if ps_output is None:
+        ps_output = subprocess.run(
+            ["ps", "-eo", "pid,etime,command"],
+            capture_output=True, text=True, timeout=15,
+        ).stdout
+    out: list[tuple[int, int, str]] = []
+    me = os.getpid()
+    for line in ps_output.splitlines()[1:]:
+        m = re.match(r"\s*(\d+)\s+(\S+)\s+(.*)", line)
+        if not m:
+            continue
+        pid, etime, command = int(m.group(1)), m.group(2), m.group(3)
+        if pid == me or not any(k in command for k in _PROC_MARKERS):
+            continue
+        if " ps -eo" in command or command.startswith("ps "):
+            continue
+        try:
+            age = _parse_etime(etime)
+        except ValueError:
+            continue
+        out.append((pid, age, command))
+    return out
+
+
+def detect_stale_processes(
+    ps_output: str | None = None,
+    *,
+    now: float | None = None,
+) -> SkewReport:
+    """Every conexus process older than the installed distribution."""
+    mtime, version = install_mtime_and_version()
+    report = SkewReport(installed_version=version, install_mtime=mtime)
+    now = time.time() if now is None else now
+    for pid, age_s, command in enumerate_processes(ps_output):
+        started = now - age_s
+        if started < mtime:
+            report.stale.append(StaleProcess(
+                pid=pid, kind=_classify(command),
+                command=command, age_s=age_s,
+            ))
+    return report
+
+
+def restart_stale(report: SkewReport, *, dry_run: bool = False) -> list[str]:
+    """Cycle the restartable classes; return human-readable action lines.
+
+    aspect-worker: killed — it respawns on demand from a fresh host (and
+    an orphaned one at ppid 1 is executing old code with no owner at all;
+    observed twice in two days). MinerU: cycled via its own lifecycle
+    verbs. MCP hosts are never touched — they belong to live Claude
+    sessions; the report names them for the human.
+    """
+    actions: list[str] = []
+    for proc in report.restartable:
+        if dry_run:
+            actions.append(f"would restart {proc.kind} (pid {proc.pid})")
+            continue
+        if proc.kind == "aspect-worker":
+            try:
+                os.kill(proc.pid, 15)
+                actions.append(
+                    f"restarted {proc.kind} (pid {proc.pid} stopped; "
+                    "respawns on demand)"
+                )
+            except (ProcessLookupError, PermissionError) as exc:
+                actions.append(f"{proc.kind} pid {proc.pid}: {exc}")
+        elif proc.kind == "mineru":
+            try:
+                subprocess.run(["nx", "mineru", "stop"], capture_output=True,
+                               timeout=60)
+                subprocess.run(["nx", "mineru", "start"], capture_output=True,
+                               timeout=300)
+                actions.append(f"cycled MinerU (was pid {proc.pid})")
+            except Exception as exc:  # noqa: BLE001 — best-effort cycle; failure surfaced in the action line
+                actions.append(f"mineru cycle failed: {exc}")
+    for proc in report.session_bound:
+        actions.append(
+            f"NEEDS HUMAN: {proc.kind} (pid {proc.pid}) belongs to a live "
+            "Claude session — exit that session to pick up "
+            f"{report.installed_version}"
+        )
+    return actions
+
+
+def install_source() -> str:
+    """Human-readable uv-receipt source: directory / pinned / PyPI.
+
+    Explains why ``uv tool upgrade`` may report "Nothing to upgrade":
+    a directory-tracking install never consults PyPI, and an ==-pinned
+    one never moves past its pin (both live incidents, 2026-07-13).
+    """
+    receipt = Path.home() / ".local/share/uv/tools/conexus/uv-receipt.toml"
+    try:
+        text = receipt.read_text()
+    except OSError:
+        return "unknown (no uv receipt)"
+    if "directory = " in text:
+        m = re.search(r'directory = "([^"]+)"', text)
+        return (
+            f"local checkout ({m.group(1) if m else '?'}) — `uv tool "
+            "upgrade` never consults PyPI for this install; use "
+            "scripts/reinstall-tool.sh or reinstall from PyPI"
+        )
+    m = re.search(r'specifier = "==([^"]+)"', text)
+    if m or "==" in text.split("requirements")[-1][:200]:
+        return (
+            "PyPI, PINNED — `uv tool upgrade` will never move past the "
+            "pin; reinstall unpinned (`uv tool install --reinstall conexus`)"
+        )
+    return "PyPI, unpinned — `uv tool upgrade conexus` upgrades normally"
+
+
+def check_version_transition(config_dir: Path) -> str | None:
+    """Version-stamp auto-trigger. Returns a one-line summary when a
+    version transition was detected and the safe finish pass ran; None
+    when the stamp is current (the overwhelmingly common case).
+
+    uv offers no post-install hook, so the first invocation after an
+    upgrade is the earliest the product can finish the job itself.
+    """
+    try:
+        _, version = install_mtime_and_version()
+    except Exception:  # noqa: BLE001 — metadata unavailable (frozen/test env): never block startup
+        return None
+    stamp = config_dir / STAMP_FILENAME
+    try:
+        seen = stamp.read_text().strip()
+    except OSError:
+        seen = ""
+    if seen == version:
+        return None
+    try:
+        config_dir.mkdir(parents=True, exist_ok=True)
+        stamp.write_text(version + "\n")
+    except OSError:
+        return None  # unwritable config dir: skip silently, retry next run
+    if not seen:
+        return None  # first-ever run: nothing stale to finish
+    try:
+        report = detect_stale_processes()
+        actions = restart_stale(report)
+    except Exception:  # noqa: BLE001 — the finish pass must never break CLI startup
+        _log.warning("upgrade_finish_failed", exc_info=True)
+        return None
+    _log.info(
+        "upgrade_finish_ran",
+        from_version=seen, to_version=version, actions=actions,
+    )
+    if not actions:
+        return f"upgraded {seen} -> {version}; no stale processes"
+    return (
+        f"upgraded {seen} -> {version}; " + "; ".join(actions)
+    )

--- a/src/nexus/upgrade_finish.py
+++ b/src/nexus/upgrade_finish.py
@@ -107,9 +107,20 @@ def install_mtime_and_version() -> tuple[float, str]:
 
     dist = md.distribution("conexus")
     version = dist.version
-    path = getattr(dist, "_path", None)
-    mtime = Path(str(path)).stat().st_mtime if path else 0.0
-    return mtime, version
+    # PUBLIC API only (review 38b7db3d Critical-1: the prior dist._path
+    # private-attr read fell back to mtime=0.0 when absent, which made
+    # `started < mtime` always false — silently disabling ALL skew detection,
+    # the exact fail-open this module exists to eliminate). locate_file("")
+    # is the documented site-packages root; the dist-info dir name is
+    # deterministic from name+version. Missing => RAISE (fail loud).
+    root = Path(str(dist.locate_file("")))
+    dist_info = root / f"conexus-{version}.dist-info"
+    if not dist_info.exists():
+        raise RuntimeError(
+            f"cannot locate conexus dist-info under {root} — "
+            "process-skew detection unavailable in this environment"
+        )
+    return dist_info.stat().st_mtime, version
 
 
 def enumerate_processes(ps_output: str | None = None) -> list[tuple[int, int, str]]:
@@ -119,10 +130,17 @@ def enumerate_processes(ps_output: str | None = None) -> list[tuple[int, int, st
     parses identically on macOS and Linux). Injectable for tests.
     """
     if ps_output is None:
-        ps_output = subprocess.run(
-            ["ps", "-eo", "pid,etime,command"],
+        proc = subprocess.run(
+            ["ps", "-wweo", "pid,etime,command"],
             capture_output=True, text=True, timeout=15,
-        ).stdout
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            # Review 38b7db3d M5: a silent empty ps = zero processes
+            # detected = the fail-open class again. Fail loud instead.
+            raise RuntimeError(
+                f"ps failed (rc={proc.returncode}): {proc.stderr.strip()[:200]}"
+            )
+        ps_output = proc.stdout
     out: list[tuple[int, int, str]] = []
     me = os.getpid()
     for line in ps_output.splitlines()[1:]:
@@ -131,8 +149,6 @@ def enumerate_processes(ps_output: str | None = None) -> list[tuple[int, int, st
             continue
         pid, etime, command = int(m.group(1)), m.group(2), m.group(3)
         if pid == me or not any(k in command for k in _PROC_MARKERS):
-            continue
-        if " ps -eo" in command or command.startswith("ps "):
             continue
         try:
             age = _parse_etime(etime)
@@ -177,7 +193,24 @@ def restart_stale(report: SkewReport, *, dry_run: bool = False) -> list[str]:
             continue
         if proc.kind == "aspect-worker":
             try:
-                os.kill(proc.pid, 15)
+                # Review 38b7db3d High-3 (pid-recycle TOCTOU): re-verify the
+                # pid still runs OUR command immediately before signaling —
+                # the same convention as t2_daemon's pre-kill re-check.
+                probe = subprocess.run(
+                    ["ps", "-p", str(proc.pid), "-o", "command="],
+                    capture_output=True, text=True, timeout=10,
+                )
+                current = probe.stdout.strip()
+                if "aspect-worker" not in current or not any(
+                    k in current for k in _PROC_MARKERS
+                ):
+                    actions.append(
+                        f"{proc.kind} pid {proc.pid}: gone or recycled; skipped"
+                    )
+                    continue
+                import signal as _signal  # noqa: PLC0415 — stdlib, deferred
+
+                os.kill(proc.pid, _signal.SIGTERM)
                 actions.append(
                     f"restarted {proc.kind} (pid {proc.pid} stopped; "
                     "respawns on demand)"
@@ -209,23 +242,30 @@ def install_source() -> str:
     a directory-tracking install never consults PyPI, and an ==-pinned
     one never moves past its pin (both live incidents, 2026-07-13).
     """
+    import tomllib  # noqa: PLC0415 — stdlib, deferred for startup cost
+
     receipt = Path.home() / ".local/share/uv/tools/conexus/uv-receipt.toml"
     try:
-        text = receipt.read_text()
-    except OSError:
-        return "unknown (no uv receipt)"
-    if "directory = " in text:
-        m = re.search(r'directory = "([^"]+)"', text)
+        data = tomllib.loads(receipt.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return "unknown (no readable uv receipt)"
+    reqs = (data.get("tool") or {}).get("requirements") or data.get("requirements") or []
+    req = next(
+        (r for r in reqs if isinstance(r, dict) and r.get("name") == "conexus"),
+        {},
+    )
+    if req.get("directory"):
         return (
-            f"local checkout ({m.group(1) if m else '?'}) — `uv tool "
-            "upgrade` never consults PyPI for this install; use "
-            "scripts/reinstall-tool.sh or reinstall from PyPI"
+            f"local checkout ({req['directory']}) — `uv tool upgrade` never "
+            "consults PyPI for this install; use scripts/reinstall-tool.sh "
+            "or reinstall from PyPI"
         )
-    m = re.search(r'specifier = "==([^"]+)"', text)
-    if m or "==" in text.split("requirements")[-1][:200]:
+    spec = str(req.get("specifier", ""))
+    if spec.startswith("=="):
         return (
-            "PyPI, PINNED — `uv tool upgrade` will never move past the "
-            "pin; reinstall unpinned (`uv tool install --reinstall conexus`)"
+            f"PyPI, PINNED ({spec}) — `uv tool upgrade` will never move "
+            "past the pin; reinstall unpinned "
+            "(`uv tool install --reinstall conexus`)"
         )
     return "PyPI, unpinned — `uv tool upgrade conexus` upgrades normally"
 
@@ -251,7 +291,23 @@ def check_version_transition(config_dir: Path) -> str | None:
         return None
     try:
         config_dir.mkdir(parents=True, exist_ok=True)
-        stamp.write_text(version + "\n")
+        # Review 38b7db3d M4: two concurrent nx invocations right after an
+        # upgrade must not BOTH run the finish pass (a doubled MinerU
+        # stop/start can race itself broken). O_EXCL claim: exactly one
+        # transitioner; losers skip (the winner's pass covers them).
+        lock = config_dir / (STAMP_FILENAME + ".lock")
+        try:
+            fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+        except FileExistsError:
+            return None
+        try:
+            stamp.write_text(version + "\n")
+        finally:
+            try:
+                lock.unlink()
+            except OSError:
+                pass
     except OSError:
         return None  # unwritable config dir: skip silently, retry next run
     if not seen:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -494,18 +494,48 @@ def _gc_col(rows: list[tuple[str, str]]):
     re-enter ``_prune_deleted_files`` (which loops over both code and
     docs collections; each iteration calls ``col.get`` at least once).
     """
-    ids = [r[0] for r in rows]
-    metas = [{"chunk_text_hash": r[1]} for r in rows]
-    state = {"calls": 0}
+    state = {
+        "rows": {r[0]: {"chunk_text_hash": r[1]} for r in rows},
+    }
 
-    def _get(*args, **kwargs):
-        state["calls"] += 1
-        if state["calls"] == 1:
-            return {"ids": list(ids), "metadatas": list(metas)}
-        return {"ids": [], "metadatas": []}
+    def _get(*args, ids=None, **kwargs):
+        if ids is not None:
+            # id-keyed fetch (the quarantine copy path): always answered
+            # from live state, with embeddings/documents so copy-then-
+            # delete round-trips.
+            present = [i for i in ids if i in state["rows"]]
+            return {
+                "ids": present,
+                "metadatas": [dict(state["rows"][i]) for i in present],
+                "documents": [f"doc-{i}" for i in present],
+                "embeddings": [[0.0, 1.0] for _ in present],
+            }
+        # full-collection page (the classification sweep): true
+        # limit/offset pagination over the LIVE state — mirrors
+        # _paginated_get's contract, survives re-scans (restore/expiry
+        # walk the same collection repeatedly), and exercises real page
+        # boundaries when a fixture exceeds the page size.
+        offset = kwargs.get("offset", 0) or 0
+        limit = kwargs.get("limit") or len(state["rows"])
+        keys = list(state["rows"])[offset:offset + limit]
+        return {
+            "ids": keys,
+            "metadatas": [dict(state["rows"][k]) for k in keys],
+        }
+
+    def _delete(*args, ids=None, **kwargs):
+        for i in ids or []:
+            state["rows"].pop(i, None)
+
+    def _upsert(*args, ids=None, metadatas=None, **kwargs):
+        for i, m in zip(ids or [], metadatas or []):
+            state["rows"][i] = dict(m or {})
 
     col = MagicMock()
     col.get.side_effect = _get
+    col.delete.side_effect = _delete
+    col.upsert.side_effect = _upsert
+    col._rows = state["rows"]
     return col
 
 
@@ -526,11 +556,21 @@ def _gc_db(per_collection_rows: dict[str, list[tuple[str, str]]]):
         name: _gc_col(rows) for name, rows in per_collection_rows.items()
     }
     db = MagicMock()
-    db.get_or_create_collection.side_effect = lambda name: cols[name]
-    db.get_collection.side_effect = lambda name: cols[name]
-    # nexus-ks40: read paths now use ``get_collection`` (raises when
-    # absent) so the mock must satisfy both name-resolution surfaces.
-    db.get_collection.side_effect = lambda name: cols[name]
+
+    def _goc(name):
+        # get_or_create: auto-create (the quarantine sibling path).
+        if name not in cols:
+            cols[name] = _gc_col([])
+        return cols[name]
+
+    def _get_only(name):
+        # nexus-ks40: read paths use get_collection (raises when absent).
+        if name not in cols:
+            raise ValueError(f"collection {name!r} not found")
+        return cols[name]
+
+    db.get_or_create_collection.side_effect = _goc
+    db.get_collection.side_effect = _get_only
     return db, cols
 
 
@@ -559,17 +599,19 @@ def test_prune_deleted_files_orphan_chunk_deleted(tmp_path):
     from nexus.indexer import _prune_deleted_files
     live_chash = "a" * 64
     orphan_chash = "b" * 64
-    col = _gc_col([("live-id-synthetic", live_chash),
-                   ("orphan-id-synthetic", orphan_chash)])
-    db = MagicMock(); db.get_or_create_collection.return_value = col
-    db.get_collection.return_value = col
+    db, cols = _gc_db({
+        "code__repo": [("live-id-synthetic", live_chash),
+                       ("orphan-id-synthetic", orphan_chash)],
+        "docs__repo": [],
+    })
     catalog = _gc_catalog({"code__repo": {live_chash[:32]}, "docs__repo": set()})
 
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
 
-    deleted = _deleted_ids(col)
-    assert "orphan-id-synthetic" in deleted
-    assert "live-id-synthetic" not in deleted
+    # nexus-xukbj: the orphan MOVES to quarantine (recoverable), the live
+    # chunk stays in the origin.
+    assert list(cols["code__repo"]._rows) == ["live-id-synthetic"]
+    assert "orphan-id-synthetic" in cols["quarantine__repo"]._rows
 
 
 def test_prune_deleted_files_preserves_live_synthetic_id(tmp_path):
@@ -580,14 +622,13 @@ def test_prune_deleted_files_preserves_live_synthetic_id(tmp_path):
     from nexus.indexer import _prune_deleted_files
     chash = "a" * 64
     synthetic_id = "0123456789abcdef" * 2  # 32 hex chars unrelated to chash
-    col = _gc_col([(synthetic_id, chash)])
-    db = MagicMock(); db.get_or_create_collection.return_value = col
-    db.get_collection.return_value = col
+    db, cols = _gc_db({"code__repo": [(synthetic_id, chash)], "docs__repo": []})
     catalog = _gc_catalog({"code__repo": {chash[:32]}, "docs__repo": set()})
 
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
 
-    assert col.delete.call_count == 0
+    assert cols["code__repo"].delete.call_count == 0
+    assert synthetic_id in cols["code__repo"]._rows
 
 
 def test_prune_deleted_files_empty_manifest_skips_no_wipe(tmp_path):
@@ -662,17 +703,13 @@ def test_prune_deleted_files_idempotent(tmp_path):
     chash = "a" * 64
     catalog = _gc_catalog({"code__repo": {chash[:32]}, "docs__repo": set()})
 
-    col = _gc_col([("live-id", chash)])
-    db = MagicMock(); db.get_or_create_collection.return_value = col
-    db.get_collection.return_value = col
+    db, cols = _gc_db({"code__repo": [("live-id", chash)], "docs__repo": []})
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-    assert col.delete.call_count == 0
+    assert cols["code__repo"].delete.call_count == 0
 
-    col2 = _gc_col([("live-id", chash)])
-    db2 = MagicMock(); db2.get_or_create_collection.return_value = col2
-    db2.get_collection.return_value = col2
-    _prune_deleted_files("code__repo", "docs__repo", db2, catalog=catalog)
-    assert col2.delete.call_count == 0
+    _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+    assert cols["code__repo"].delete.call_count == 0
+    assert list(cols["code__repo"]._rows) == ["live-id"]
 
 
 def test_prune_deleted_files_no_catalog_is_noop(tmp_path):
@@ -1712,43 +1749,21 @@ def test_on_stage_timers_none_is_safe(tmp_path):
 
 def test_prune_deleted_files_paginates(tmp_path, monkeypatch):
     """RDR-108 Phase 4 / nexus-dyxe: pagination still walks the whole
-    collection and deletes orphans across page boundaries. (This fixture's
-    110/310 = 35.5% orphan fraction trips the nexus-mr89x safety floor by
-    design; the explicit override applies because pagination, not floor
-    policy, is under test — floor policy has its own TestGcSafetyFloor.)"""
-    monkeypatch.setenv("NX_GC_FORCE", "1")
+    collection across page boundaries (310 rows > _CHROMA_PAGE_SIZE=300).
+    Post-xukbj the orphans MOVE to quarantine rather than hard-delete;
+    lives stay put."""
+    monkeypatch.delenv("NX_GC_FORCE", raising=False)
     from nexus.indexer import _prune_deleted_files
     live = [(f"live-{i:03d}", f"a{i:03d}" + "0" * 60) for i in range(200)]
     orphan = [(f"orphan-{i:03d}", f"b{i:03d}" + "0" * 60) for i in range(110)]
-    live_ids = {r[0] for r in live}
-    orphan_ids = {r[0] for r in orphan}
     live_chashes_32 = {r[1][:32] for r in live}
-    # Force pagination by filling page 1 to exactly _CHROMA_PAGE_SIZE=300 rows
-    # so the helper continues to page 2 instead of short-circuiting.
-    p1_rows = live + orphan[:100]
-    p2_rows = orphan[100:]
-    p1 = {"ids": [r[0] for r in p1_rows],
-          "metadatas": [{"chunk_text_hash": r[1]} for r in p1_rows]}
-    p2 = {"ids": [r[0] for r in p2_rows],
-          "metadatas": [{"chunk_text_hash": r[1]} for r in p2_rows]}
-    p3 = {"ids": [], "metadatas": []}
-    mock_cols: list[MagicMock] = []
-    def mc():
-        c = MagicMock(); c.get.side_effect = [p1, p2, p3]; return c
-    db = MagicMock()
-    db.get_or_create_collection.side_effect = lambda _: (mock_cols.append(mc()), mock_cols[-1])[1]
-    db.get_collection.side_effect = lambda _: (mock_cols.append(mc()), mock_cols[-1])[1]
-    db.get_collection.side_effect = lambda _: (mock_cols.append(mc()), mock_cols[-1])[1]
-    catalog = _gc_catalog({"code__repo": live_chashes_32, "docs__repo": live_chashes_32})
+    db, cols = _gc_db({"code__repo": live + orphan, "docs__repo": []})
+    catalog = _gc_catalog({"code__repo": live_chashes_32, "docs__repo": set()})
 
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
 
-    for col in mock_cols:
-        d = set()
-        for c in col.delete.call_args_list:
-            d.update(c.kwargs.get("ids") or (c.args[0] if c.args else []))
-        assert orphan_ids.issubset(d)
-        assert not live_ids.intersection(d)
+    assert set(cols["code__repo"]._rows) == {r[0] for r in live}
+    assert set(cols["quarantine__repo"]._rows) == {r[0] for r in orphan}
 
 
 def test_frecency_update_paginates(tmp_path):
@@ -2079,149 +2094,125 @@ def test_drain_markers_on_phase_none_safe():
     assert _drain_batcher_with_markers(b, None) == 1
 
 
-class TestGcSafetyFloor:
-    """nexus-mr89x (a): the partial-gap safety floor — the sibling of the
-    manifest-empty guard for the manifest-PARTIAL case. A collection-name
-    stamp mismatch or mass manifest drop classifies ~all chunks as orphans;
-    the 2026-07-09 field incident pruned 6 live RDR docs that way."""
+class TestQuarantineLifecycle:
+    """nexus-xukbj (soft delete): orphans MOVE to the quarantine sibling
+    (never a recurring refusal warning — the mr89x nag this replaced);
+    re-referenced chashes restore; the mr89x safety floor now guards only
+    the EXPIRY hard-delete after the grace window."""
 
     @staticmethod
-    def _mass_orphan_setup(n_total=200, n_live=20):
-        """n_total chunks, only n_live referenced -> 90% orphan verdict."""
+    def _setup(n_total=200, n_live=20, name="code__repo"):
         rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(n_total)]
         live = {r[1][:32] for r in rows[:n_live]}
-        col = _gc_col(rows)
-        db = MagicMock()
-        db.get_or_create_collection.return_value = col
-        db.get_collection.return_value = col
-        catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
-        return col, db, catalog
+        db, cols = _gc_db({name: rows, "docs__repo": []})
+        catalog = _gc_catalog({name: live, "docs__repo": set()})
+        return rows, live, db, cols, catalog
 
-    def test_mass_orphan_verdict_refused(self, monkeypatch):
+    def test_mass_orphan_verdict_quarantines_not_refuses(self, monkeypatch):
+        """The 90%-orphan shape that used to refuse forever now moves to
+        quarantine silently: origin keeps only live chunks, the sibling
+        holds the orphans with quarantined_at + origin stamped."""
         from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
-        col, db, catalog = self._mass_orphan_setup()
+        rows, live, db, cols, catalog = self._setup()
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert _deleted_ids(col) == []  # refused: nothing deleted
+        origin = cols["code__repo"]._rows
+        q = cols["quarantine__repo"]._rows
+        assert len(origin) == 20 and len(q) == 180
+        sample = next(iter(q.values()))
+        assert sample["origin_collection"] == "code__repo"
+        assert sample["quarantined_at"]
 
-    def test_operator_override_allows_the_sweep(self, monkeypatch):
-        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
-        monkeypatch.setenv("NX_GC_FORCE", "1")
-        col, db, catalog = self._mass_orphan_setup()
-        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert len(_deleted_ids(col)) == 180  # explicit override sweeps
-
-    def test_under_floor_fraction_prunes_normally(self, monkeypatch):
-        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
-        monkeypatch.delenv("NX_GC_FORCE", raising=False)
-        # 200 chunks, 120 live -> 40% orphans: under the 50% floor.
-        col, db, catalog = self._mass_orphan_setup(n_total=200, n_live=120)
-        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert len(_deleted_ids(col)) == 80
-
-    def test_small_collection_exempt_from_floor(self, monkeypatch):
+    def test_field_incident_shape_quarantines(self, monkeypatch):
+        """154/551 = 27.9% (the 2026-07-09 incident): recoverable move,
+        no refusal, no warning."""
         from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
-        # ~89% orphan verdict but only 8 orphans (< _GC_FLOOR_MIN_CHUNKS):
-        # plausible real cleanup of a tiny corpus — must still prune.
-        # (n_live=1 keeps the manifest non-empty so the older oqku
-        # empty-manifest guard does not preempt this case.)
-        col, db, catalog = self._mass_orphan_setup(n_total=9, n_live=1)
+        rows, live, db, cols, catalog = self._setup(n_total=551, n_live=397)
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert len(_deleted_ids(col)) == 8
+        assert len(cols["code__repo"]._rows) == 397
+        assert len(cols["quarantine__repo"]._rows) == 154
 
-
-class TestGcSafetyFloorReviewHardening:
-    """Review e2423e3b findings: the floor must catch the ACTUAL field
-    incident shape, survive malformed configuration, isolate per
-    collection, and hold at its boundaries."""
-
-    def test_field_incident_shape_is_refused(self, monkeypatch):
-        """Critical-2: the 2026-07-09 incident condemned 154/551 = 27.9% —
-        the original 0.5 default sailed it through. The 0.25 default must
-        refuse exactly this shape."""
+    def test_rereferenced_chashes_restore_from_quarantine(self, monkeypatch):
+        """A heal that re-references quarantined chashes copies them back
+        (and strips the quarantine stamps) before orphan classification —
+        the recoverability the whole design exists for."""
         from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
-        monkeypatch.delenv("NX_GC_FLOOR_FRACTION", raising=False)
-        rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(551)]
-        live = {r[1][:32] for r in rows[:397]}  # 154 orphans = 27.9%
-        col = _gc_col(rows)
-        db = MagicMock()
-        db.get_or_create_collection.return_value = col
-        db.get_collection.return_value = col
-        catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
+        rows, live, db, cols, catalog = self._setup()
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert _deleted_ids(col) == []
+        assert len(cols["quarantine__repo"]._rows) == 180
+        # The manifest now references EVERYTHING (heal healed the gap).
+        catalog2 = _gc_catalog({
+            "code__repo": {r[1][:32] for r in rows}, "docs__repo": set(),
+        })
+        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog2)
+        assert len(cols["code__repo"]._rows) == 200
+        assert len(cols["quarantine__repo"]._rows) == 0
+        restored = cols["code__repo"]._rows["id-0150"]
+        assert "quarantined_at" not in restored
+        assert "origin_collection" not in restored
 
-    def test_malformed_floor_env_never_crashes_and_keeps_the_guard(
+    def test_expiry_hard_deletes_past_grace_and_floor_guards_mass(
         self, monkeypatch,
     ):
-        """Critical-1 + F6: a malformed / nan / inf NX_GC_FLOOR_FRACTION
-        must not crash the index run NOR silently neutralize the guard —
-        it falls back to the default (which refuses a 90% verdict)."""
-        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+        """Rows older than the grace window hard-delete; a MASS expiry
+        (the persisted-defect shape) is refused by the relocated mr89x
+        floor unless NX_GC_FORCE=1. Also pins the fail-safe env parse."""
+        from nexus.catalog.chunk_quarantine import expire_quarantine  # noqa: PLC0415 — file pattern: deferred imports
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
-        for bad in ("not-a-float", "nan", "inf", "-3", "7"):
-            monkeypatch.setenv("NX_GC_FLOOR_FRACTION", bad)
-            rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(200)]
-            live = {r[1][:32] for r in rows[:20]}
-            col = _gc_col(rows)
-            db = MagicMock()
-            db.get_or_create_collection.return_value = col
-            db.get_collection.return_value = col
-            catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
-            _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-            assert _deleted_ids(col) == [], f"guard neutralized by {bad!r}"
+        old = "2020-01-01T00:00:00Z"
+        rows = [(f"q-{i:04d}", f"{i:032d}" + "e" * 32) for i in range(150)]
+        db, cols = _gc_db({"quarantine__repo": rows})
+        for m in cols["quarantine__repo"]._rows.values():
+            m["quarantined_at"] = old
+        # 100% of 150 expiring >= floor -> refused.
+        expired, refused = expire_quarantine(
+            db, "code__repo", floor_fraction=0.25, floor_min_chunks=100,
+        )
+        assert (expired, refused) == (0, 150)
+        assert len(cols["quarantine__repo"]._rows) == 150
+        # Explicit override sweeps.
+        monkeypatch.setenv("NX_GC_FORCE", "1")
+        expired, refused = expire_quarantine(
+            db, "code__repo", floor_fraction=0.25, floor_min_chunks=100,
+        )
+        assert (expired, refused) == (150, 0)
+        assert len(cols["quarantine__repo"]._rows) == 0
 
-    def test_fraction_gate_isolated_at_scale(self, monkeypatch):
-        """F3b: orphans >= the count gate (125 >= 100) but fraction under
-        the floor (125/625 = 20% < 25%) — must prune. Isolates the
-        fraction gate from the count gate."""
-        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+    def test_small_or_fresh_quarantine_expires_normally(self, monkeypatch):
+        """Under the floor's min-chunk gate, expiry proceeds; fresh rows
+        (inside grace) never expire; malformed NX_GC_QUARANTINE_DAYS falls
+        back safely."""
+        from nexus.catalog.chunk_quarantine import expire_quarantine  # noqa: PLC0415 — file pattern: deferred imports
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
-        monkeypatch.delenv("NX_GC_FLOOR_FRACTION", raising=False)
-        rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(625)]
-        live = {r[1][:32] for r in rows[:500]}
-        col = _gc_col(rows)
-        db = MagicMock()
-        db.get_or_create_collection.return_value = col
-        db.get_collection.return_value = col
-        catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
-        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert len(_deleted_ids(col)) == 125
+        monkeypatch.setenv("NX_GC_QUARANTINE_DAYS", "not-a-number")
+        rows = [(f"q-{i:02d}", f"{i:032d}" + "e" * 32) for i in range(10)]
+        db, cols = _gc_db({"quarantine__repo": rows})
+        items = list(cols["quarantine__repo"]._rows.values())
+        for m in items[:6]:
+            m["quarantined_at"] = "2020-01-01T00:00:00Z"
+        for m in items[6:]:
+            m["quarantined_at"] = "9998-01-01T00:00:00Z"
+        expired, refused = expire_quarantine(
+            db, "code__repo", floor_fraction=0.25, floor_min_chunks=100,
+        )
+        assert (expired, refused) == (6, 0)
+        assert len(cols["quarantine__repo"]._rows) == 4
 
-    def test_exact_floor_fraction_is_not_refused(self, monkeypatch):
-        """Boundary: frac == floor is NOT refused (strict >). 150/600 = 25%
-        exactly at the default floor -> prunes."""
+    def test_quarantine_isolated_per_collection(self, monkeypatch):
+        """A mass move in code__ never touches docs__ (the v7mn distinct-
+        collection discipline)."""
         from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
-        monkeypatch.delenv("NX_GC_FLOOR_FRACTION", raising=False)
-        rows = [(f"id-{i:04d}", f"{i:032d}" + "f" * 32) for i in range(600)]
-        live = {r[1][:32] for r in rows[:450]}
-        col = _gc_col(rows)
-        db = MagicMock()
-        db.get_or_create_collection.return_value = col
-        db.get_collection.return_value = col
-        catalog = _gc_catalog({"code__repo": live, "docs__repo": set()})
-        _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert len(_deleted_ids(col)) == 150
-
-    def test_refused_collection_does_not_block_others(self, monkeypatch):
-        """F3: per-collection isolation through DISTINCT collections (the
-        _gc_db pattern the file's own docstring mandates — the shared-mock
-        shortcut masked this contract). code__repo is a mass-orphan refusal;
-        docs__repo has one genuine orphan that must still prune."""
-        from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
-        monkeypatch.delenv("NX_GC_FORCE", raising=False)
-        monkeypatch.delenv("NX_GC_FLOOR_FRACTION", raising=False)
-        code_rows = [(f"code-{i:04d}", f"{i:032d}" + "c" * 32) for i in range(200)]
-        code_live = {r[1][:32] for r in code_rows[:20]}  # 90% orphan -> refuse
-        docs_rows = [("docs-live", "a" * 64), ("docs-orphan", "b" * 64)]
+        code_rows = [(f"c-{i:03d}", f"{i:032d}" + "c" * 32) for i in range(150)]
+        docs_rows = [("d-live", "a" * 64), ("d-orphan", "b" * 64)]
         db, cols = _gc_db({"code__repo": code_rows, "docs__repo": docs_rows})
         catalog = _gc_catalog({
-            "code__repo": code_live,
+            "code__repo": {r[1][:32] for r in code_rows[:10]},
             "docs__repo": {("a" * 64)[:32]},
         })
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert _deleted_ids(cols["code__repo"]) == []  # refused
-        assert _deleted_ids(cols["docs__repo"]) == ["docs-orphan"]  # pruned
+        assert len(cols["code__repo"]._rows) == 10
+        assert len(cols["quarantine__repo"]._rows) == 140 + 1  # both origins share owner suffix
+        assert list(cols["docs__repo"]._rows) == ["d-live"]

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -571,6 +571,10 @@ def _gc_db(per_collection_rows: dict[str, list[tuple[str, str]]]):
 
     db.get_or_create_collection.side_effect = _goc
     db.get_collection.side_effect = _get_only
+    # Local-mode shape: a bare MagicMock's auto-attrs would make the db
+    # look service-mode (truthy upsert_chunks_with_embeddings) and swallow
+    # quarantine writes silently (review 4cb743be H3 — permissive mocks).
+    db.upsert_chunks_with_embeddings = None
     return db, cols
 
 
@@ -611,7 +615,7 @@ def test_prune_deleted_files_orphan_chunk_deleted(tmp_path):
     # nexus-xukbj: the orphan MOVES to quarantine (recoverable), the live
     # chunk stays in the origin.
     assert list(cols["code__repo"]._rows) == ["live-id-synthetic"]
-    assert "orphan-id-synthetic" in cols["quarantine__repo"]._rows
+    assert "orphan-id-synthetic" in cols["quarantine-code__repo"]._rows
 
 
 def test_prune_deleted_files_preserves_live_synthetic_id(tmp_path):
@@ -1763,7 +1767,7 @@ def test_prune_deleted_files_paginates(tmp_path, monkeypatch):
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
 
     assert set(cols["code__repo"]._rows) == {r[0] for r in live}
-    assert set(cols["quarantine__repo"]._rows) == {r[0] for r in orphan}
+    assert set(cols["quarantine-code__repo"]._rows) == {r[0] for r in orphan}
 
 
 def test_frecency_update_paginates(tmp_path):
@@ -2117,7 +2121,7 @@ class TestQuarantineLifecycle:
         rows, live, db, cols, catalog = self._setup()
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
         origin = cols["code__repo"]._rows
-        q = cols["quarantine__repo"]._rows
+        q = cols["quarantine-code__repo"]._rows
         assert len(origin) == 20 and len(q) == 180
         sample = next(iter(q.values()))
         assert sample["origin_collection"] == "code__repo"
@@ -2131,7 +2135,7 @@ class TestQuarantineLifecycle:
         rows, live, db, cols, catalog = self._setup(n_total=551, n_live=397)
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
         assert len(cols["code__repo"]._rows) == 397
-        assert len(cols["quarantine__repo"]._rows) == 154
+        assert len(cols["quarantine-code__repo"]._rows) == 154
 
     def test_rereferenced_chashes_restore_from_quarantine(self, monkeypatch):
         """A heal that re-references quarantined chashes copies them back
@@ -2141,14 +2145,14 @@ class TestQuarantineLifecycle:
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
         rows, live, db, cols, catalog = self._setup()
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
-        assert len(cols["quarantine__repo"]._rows) == 180
+        assert len(cols["quarantine-code__repo"]._rows) == 180
         # The manifest now references EVERYTHING (heal healed the gap).
         catalog2 = _gc_catalog({
             "code__repo": {r[1][:32] for r in rows}, "docs__repo": set(),
         })
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog2)
         assert len(cols["code__repo"]._rows) == 200
-        assert len(cols["quarantine__repo"]._rows) == 0
+        assert len(cols["quarantine-code__repo"]._rows) == 0
         restored = cols["code__repo"]._rows["id-0150"]
         assert "quarantined_at" not in restored
         assert "origin_collection" not in restored
@@ -2163,22 +2167,22 @@ class TestQuarantineLifecycle:
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
         old = "2020-01-01T00:00:00Z"
         rows = [(f"q-{i:04d}", f"{i:032d}" + "e" * 32) for i in range(150)]
-        db, cols = _gc_db({"quarantine__repo": rows})
-        for m in cols["quarantine__repo"]._rows.values():
+        db, cols = _gc_db({"quarantine-code__repo": rows})
+        for m in cols["quarantine-code__repo"]._rows.values():
             m["quarantined_at"] = old
         # 100% of 150 expiring >= floor -> refused.
         expired, refused = expire_quarantine(
             db, "code__repo", floor_fraction=0.25, floor_min_chunks=100,
         )
         assert (expired, refused) == (0, 150)
-        assert len(cols["quarantine__repo"]._rows) == 150
+        assert len(cols["quarantine-code__repo"]._rows) == 150
         # Explicit override sweeps.
         monkeypatch.setenv("NX_GC_FORCE", "1")
         expired, refused = expire_quarantine(
             db, "code__repo", floor_fraction=0.25, floor_min_chunks=100,
         )
         assert (expired, refused) == (150, 0)
-        assert len(cols["quarantine__repo"]._rows) == 0
+        assert len(cols["quarantine-code__repo"]._rows) == 0
 
     def test_small_or_fresh_quarantine_expires_normally(self, monkeypatch):
         """Under the floor's min-chunk gate, expiry proceeds; fresh rows
@@ -2188,8 +2192,8 @@ class TestQuarantineLifecycle:
         monkeypatch.delenv("NX_GC_FORCE", raising=False)
         monkeypatch.setenv("NX_GC_QUARANTINE_DAYS", "not-a-number")
         rows = [(f"q-{i:02d}", f"{i:032d}" + "e" * 32) for i in range(10)]
-        db, cols = _gc_db({"quarantine__repo": rows})
-        items = list(cols["quarantine__repo"]._rows.values())
+        db, cols = _gc_db({"quarantine-code__repo": rows})
+        items = list(cols["quarantine-code__repo"]._rows.values())
         for m in items[:6]:
             m["quarantined_at"] = "2020-01-01T00:00:00Z"
         for m in items[6:]:
@@ -2198,7 +2202,7 @@ class TestQuarantineLifecycle:
             db, "code__repo", floor_fraction=0.25, floor_min_chunks=100,
         )
         assert (expired, refused) == (6, 0)
-        assert len(cols["quarantine__repo"]._rows) == 4
+        assert len(cols["quarantine-code__repo"]._rows) == 4
 
     def test_quarantine_isolated_per_collection(self, monkeypatch):
         """A mass move in code__ never touches docs__ (the v7mn distinct-
@@ -2214,5 +2218,41 @@ class TestQuarantineLifecycle:
         })
         _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
         assert len(cols["code__repo"]._rows) == 10
-        assert len(cols["quarantine__repo"]._rows) == 140 + 1  # both origins share owner suffix
+        # Review 4cb743be C3 fix: each origin owns a DISTINCT sibling —
+        # the code__ mass move and the docs__ single orphan land apart.
+        assert len(cols["quarantine-code__repo"]._rows) == 140
+        assert list(cols["quarantine-docs__repo"]._rows) == ["d-orphan"]
         assert list(cols["docs__repo"]._rows) == ["d-live"]
+
+
+def test_quarantine_siblings_distinct_for_shared_owner_and_chash(monkeypatch):
+    """Critique 4cb743be Critical-1, realistic shape: docs__ and rdr__ of
+    the SAME repo share owner + embedding model (RDR-103), and identical
+    boilerplate can share a chash across both. Per-type siblings keep the
+    two moves apart, restore stays origin-faithful, and the expiry floor's
+    denominator is never cross-contaminated."""
+    from nexus.catalog.chunk_quarantine import quarantine_collection_name  # noqa: PLC0415 — file pattern: deferred imports
+    from nexus.indexer import _prune_deleted_files  # noqa: PLC0415 — file pattern: deferred imports
+
+    monkeypatch.delenv("NX_GC_FORCE", raising=False)
+    docs = "docs__nexus-1-1__voyage-context-3__v1"
+    rdr = "rdr__nexus-1-1__voyage-context-3__v1"
+    assert quarantine_collection_name(docs) != quarantine_collection_name(rdr)
+
+    shared = "c" * 64  # identical boilerplate chunk in both collections
+    db, cols = _gc_db({docs: [("d-1", shared)], rdr: [("r-1", shared)]})
+    catalog = _gc_catalog({docs: set(), rdr: set()})
+    # Empty-manifest guard would skip; give each a live row + manifest ref.
+    db2, cols2 = _gc_db({
+        docs: [("d-live", "a" * 64), ("d-1", shared)],
+        rdr: [("r-live", "b" * 64), ("r-1", shared)],
+    })
+    catalog2 = _gc_catalog({
+        docs: {("a" * 64)[:32]}, rdr: {("b" * 64)[:32]},
+    })
+    _prune_deleted_files(docs, rdr, db2, catalog=catalog2)
+    qd = cols2[quarantine_collection_name(docs)]._rows
+    qr = cols2[quarantine_collection_name(rdr)]._rows
+    assert list(qd) == ["d-1"] and list(qr) == ["r-1"]
+    assert qd["d-1"]["origin_collection"] == docs
+    assert qr["r-1"]["origin_collection"] == rdr

--- a/tests/test_upgrade_finish.py
+++ b/tests/test_upgrade_finish.py
@@ -41,9 +41,19 @@ class TestEtimeParse:
         assert _parse_etime("8-00:00:05") == 8 * 86400 + 5
 
 
+_TOOL_ROOT = "/Users/u/.local/share/uv/tools/conexus/lib/python3.12/site-packages"
+
+
+def _pin_tool_root():
+    from pathlib import Path as _P  # noqa: PLC0415 — file pattern: deferred imports
+
+    return patch("nexus.upgrade_finish._install_root", return_value=_P(_TOOL_ROOT))
+
+
 class TestEnumerate:
     def test_filters_to_conexus_processes(self):
-        procs = enumerate_processes(_PS)
+        with _pin_tool_root():
+            procs = enumerate_processes(_PS)
         pids = [p[0] for p in procs]
         assert pids == [100, 101, 200, 300]  # vim + the ps probe excluded
 
@@ -51,7 +61,7 @@ class TestEnumerate:
         with patch(
             "nexus.upgrade_finish.install_mtime_and_version",
             return_value=(1_000_000.0, "6.7.1"),
-        ):
+        ), _pin_tool_root():
             # now = install + 30min: the 1h-old MCP pair and the multi-day
             # daemons all predate the install -> all stale.
             report = detect_stale_processes(_PS, now=1_000_000.0 + 1800)
@@ -67,7 +77,7 @@ class TestEnumerate:
         with patch(
             "nexus.upgrade_finish.install_mtime_and_version",
             return_value=(1_000_000.0, "6.7.1"),
-        ):
+        ), _pin_tool_root():
             # now = install + 10 days: everything in the fixture STARTED
             # after the install (ages < 10 days except the 8-day mineru...
             # 8d < 10d so started 2 days AFTER install -> fresh).
@@ -104,11 +114,19 @@ class TestRestartStale:
             "/u/.local/share/uv/tools/conexus/bin/python3 "
             "/u/.local/bin/nx daemon aspect-worker start\n"
         ))
-        with patch("nexus.upgrade_finish.os.kill") as k, \
+
+        calls = []
+
+        def _kill(pid, sig):
+            calls.append((pid, sig))
+            if sig == 0:
+                raise ProcessLookupError  # drained on first poll
+        with patch("nexus.upgrade_finish.os.kill", side_effect=_kill), \
+                patch("nexus.upgrade_finish.time.sleep"), \
                 patch("nexus.upgrade_finish.subprocess.run", return_value=probe):
             actions = restart_stale(self._report())
-        k.assert_called_once_with(200, signal.SIGTERM)
-        assert any("restarted aspect-worker" in a for a in actions)
+        assert calls[0] == (200, signal.SIGTERM)
+        assert any("restarted aspect-worker" in a and "drained" in a for a in actions)
         # MCP hosts are NEVER killed — a live Claude session owns them.
         assert any("pid 100" in a and "NEEDS HUMAN" in a for a in actions)
 
@@ -132,6 +150,10 @@ class TestVersionTransition:
 
     def test_transition_runs_finish_and_summarizes(self, tmp_path):
         (tmp_path / "last_seen_version").write_text("6.7.0\n")
+        self._tool = patch(
+            "nexus.upgrade_finish.running_from_tool_install", return_value=True,
+        )
+        self._tool.start()
         with patch(
             "nexus.upgrade_finish.install_mtime_and_version",
             return_value=(0.0, "6.7.1"),
@@ -140,11 +162,16 @@ class TestVersionTransition:
             return_value=SkewReport(installed_version="6.7.1"),
         ):
             line = check_version_transition(tmp_path)
+        self._tool.stop()
         assert line == "upgraded 6.7.0 -> 6.7.1; no stale processes"
         assert (tmp_path / "last_seen_version").read_text().strip() == "6.7.1"
 
     def test_transition_reports_actions(self, tmp_path):
         (tmp_path / "last_seen_version").write_text("6.7.0\n")
+        self._tool = patch(
+            "nexus.upgrade_finish.running_from_tool_install", return_value=True,
+        )
+        self._tool.start()
         r = SkewReport(installed_version="6.7.1")
         r.stale = [StaleProcess(pid=7, kind="mcp-host", command="m", age_s=9)]
         with patch(
@@ -154,6 +181,7 @@ class TestVersionTransition:
             "nexus.upgrade_finish.detect_stale_processes", return_value=r,
         ):
             line = check_version_transition(tmp_path)
+        self._tool.stop()
         assert "NEEDS HUMAN" in line and "6.7.0 -> 6.7.1" in line
 
     def test_finish_failure_never_blocks_startup(self, tmp_path):
@@ -164,6 +192,8 @@ class TestVersionTransition:
         ), patch(
             "nexus.upgrade_finish.detect_stale_processes",
             side_effect=RuntimeError("ps exploded"),
+        ), patch(
+            "nexus.upgrade_finish.running_from_tool_install", return_value=True,
         ):
             assert check_version_transition(tmp_path) is None
         # Stamp still advanced: the transition is consumed, not retried
@@ -212,3 +242,23 @@ class TestFailLoud:
         with patch("nexus.upgrade_finish.subprocess.run", return_value=bad), \
                 _pytest.raises(RuntimeError, match="ps failed"):
             enumerate_processes(None)
+
+
+class TestCrossVenvGuard:
+    def test_dev_venv_never_runs_the_finish_pass(self, tmp_path):
+        """Critique 38b7db3d C2: a dev checkout's venv mtime says nothing
+        about production processes — the transition consumes the stamp but
+        the restart pass never runs from a non-tool interpreter."""
+        (tmp_path / "last_seen_version").write_text("6.7.0\n")
+        with patch(
+            "nexus.upgrade_finish.install_mtime_and_version",
+            return_value=(0.0, "6.7.1"),
+        ), patch(
+            "nexus.upgrade_finish.running_from_tool_install",
+            return_value=False,
+        ), patch(
+            "nexus.upgrade_finish.detect_stale_processes",
+        ) as detect:
+            assert check_version_transition(tmp_path) is None
+        detect.assert_not_called()
+        assert (tmp_path / "last_seen_version").read_text().strip() == "6.7.1"

--- a/tests/test_upgrade_finish.py
+++ b/tests/test_upgrade_finish.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-4xgfy: process-skew detection + finish-the-upgrade choreography.
+
+Motivated by the 6.7.0/6.7.1 live upgrades: doctor said 'latest' while
+every running process executed the old code from memory; the aspect-worker
+orphaned to ppid 1 twice in two days; MinerU sat dead in the OOM-risk
+fallback until a human noticed. All fixture-driven: `ps` output and dist
+metadata are injectable, no real processes are touched.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from nexus.upgrade_finish import (
+    SkewReport,
+    StaleProcess,
+    _parse_etime,
+    check_version_transition,
+    detect_stale_processes,
+    enumerate_processes,
+    restart_stale,
+)
+
+_PS = """\
+  PID ELAPSED COMMAND
+  100 01:00:00 /Users/u/.local/share/uv/tools/conexus/bin/python3 /Users/u/.local/bin/nx-mcp
+  101 01:00:00 /Users/u/.local/share/uv/tools/conexus/bin/python3 /Users/u/.local/bin/nx-mcp-catalog
+  200 2-03:00:00 /Users/u/.local/share/uv/tools/conexus/bin/python3 /Users/u/.local/bin/nx daemon aspect-worker start --config-dir /x
+  300 8-00:00:05 /Users/u/.local/share/uv/tools/conexus/bin/mineru-api --host 127.0.0.1
+  400 00:05 /usr/bin/vim unrelated.txt
+  500 03:00 ps -eo pid,etime,command
+"""
+
+
+class TestEtimeParse:
+    def test_forms(self):
+        assert _parse_etime("00:05") == 5
+        assert _parse_etime("03:00") == 180
+        assert _parse_etime("01:00:00") == 3600
+        assert _parse_etime("2-03:00:00") == 2 * 86400 + 3 * 3600
+        assert _parse_etime("8-00:00:05") == 8 * 86400 + 5
+
+
+class TestEnumerate:
+    def test_filters_to_conexus_processes(self):
+        procs = enumerate_processes(_PS)
+        pids = [p[0] for p in procs]
+        assert pids == [100, 101, 200, 300]  # vim + the ps probe excluded
+
+    def test_classification_via_detect(self):
+        with patch(
+            "nexus.upgrade_finish.install_mtime_and_version",
+            return_value=(1_000_000.0, "6.7.1"),
+        ):
+            # now = install + 30min: the 1h-old MCP pair and the multi-day
+            # daemons all predate the install -> all stale.
+            report = detect_stale_processes(_PS, now=1_000_000.0 + 1800)
+        kinds = {p.pid: p.kind for p in report.stale}
+        assert kinds == {
+            100: "mcp-host", 101: "mcp-host",
+            200: "aspect-worker", 300: "mineru",
+        }
+        assert {p.pid for p in report.restartable} == {200, 300}
+        assert {p.pid for p in report.session_bound} == {100, 101}
+
+    def test_fresh_processes_are_not_stale(self):
+        with patch(
+            "nexus.upgrade_finish.install_mtime_and_version",
+            return_value=(1_000_000.0, "6.7.1"),
+        ):
+            # now = install + 10 days: everything in the fixture STARTED
+            # after the install (ages < 10 days except the 8-day mineru...
+            # 8d < 10d so started 2 days AFTER install -> fresh).
+            report = detect_stale_processes(_PS, now=1_000_000.0 + 10 * 86400)
+        assert report.stale == []
+
+
+class TestRestartStale:
+    @staticmethod
+    def _report() -> SkewReport:
+        r = SkewReport(installed_version="6.7.1")
+        r.stale = [
+            StaleProcess(pid=200, kind="aspect-worker", command="w", age_s=99),
+            StaleProcess(pid=100, kind="mcp-host", command="m", age_s=99),
+        ]
+        return r
+
+    def test_dry_run_touches_nothing(self):
+        with patch("nexus.upgrade_finish.os.kill") as k:
+            actions = restart_stale(self._report(), dry_run=True)
+        k.assert_not_called()
+        assert any("would restart aspect-worker" in a for a in actions)
+        assert any("NEEDS HUMAN: mcp-host" in a for a in actions)
+
+    def test_kills_worker_reports_session_bound(self):
+        with patch("nexus.upgrade_finish.os.kill") as k:
+            actions = restart_stale(self._report())
+        k.assert_called_once_with(200, 15)
+        assert any("restarted aspect-worker" in a for a in actions)
+        # MCP hosts are NEVER killed — a live Claude session owns them.
+        assert any("pid 100" in a and "NEEDS HUMAN" in a for a in actions)
+
+
+class TestVersionTransition:
+    def test_first_run_stamps_quietly(self, tmp_path):
+        with patch(
+            "nexus.upgrade_finish.install_mtime_and_version",
+            return_value=(0.0, "6.7.1"),
+        ):
+            assert check_version_transition(tmp_path) is None
+        assert (tmp_path / "last_seen_version").read_text().strip() == "6.7.1"
+
+    def test_same_version_is_silent_noop(self, tmp_path):
+        (tmp_path / "last_seen_version").write_text("6.7.1\n")
+        with patch(
+            "nexus.upgrade_finish.install_mtime_and_version",
+            return_value=(0.0, "6.7.1"),
+        ):
+            assert check_version_transition(tmp_path) is None
+
+    def test_transition_runs_finish_and_summarizes(self, tmp_path):
+        (tmp_path / "last_seen_version").write_text("6.7.0\n")
+        with patch(
+            "nexus.upgrade_finish.install_mtime_and_version",
+            return_value=(0.0, "6.7.1"),
+        ), patch(
+            "nexus.upgrade_finish.detect_stale_processes",
+            return_value=SkewReport(installed_version="6.7.1"),
+        ):
+            line = check_version_transition(tmp_path)
+        assert line == "upgraded 6.7.0 -> 6.7.1; no stale processes"
+        assert (tmp_path / "last_seen_version").read_text().strip() == "6.7.1"
+
+    def test_transition_reports_actions(self, tmp_path):
+        (tmp_path / "last_seen_version").write_text("6.7.0\n")
+        r = SkewReport(installed_version="6.7.1")
+        r.stale = [StaleProcess(pid=7, kind="mcp-host", command="m", age_s=9)]
+        with patch(
+            "nexus.upgrade_finish.install_mtime_and_version",
+            return_value=(0.0, "6.7.1"),
+        ), patch(
+            "nexus.upgrade_finish.detect_stale_processes", return_value=r,
+        ):
+            line = check_version_transition(tmp_path)
+        assert "NEEDS HUMAN" in line and "6.7.0 -> 6.7.1" in line
+
+    def test_finish_failure_never_blocks_startup(self, tmp_path):
+        (tmp_path / "last_seen_version").write_text("6.7.0\n")
+        with patch(
+            "nexus.upgrade_finish.install_mtime_and_version",
+            return_value=(0.0, "6.7.1"),
+        ), patch(
+            "nexus.upgrade_finish.detect_stale_processes",
+            side_effect=RuntimeError("ps exploded"),
+        ):
+            assert check_version_transition(tmp_path) is None
+        # Stamp still advanced: the transition is consumed, not retried
+        # forever against a broken probe.
+        assert (tmp_path / "last_seen_version").read_text().strip() == "6.7.1"

--- a/tests/test_upgrade_finish.py
+++ b/tests/test_upgrade_finish.py
@@ -86,16 +86,28 @@ class TestRestartStale:
         return r
 
     def test_dry_run_touches_nothing(self):
-        with patch("nexus.upgrade_finish.os.kill") as k:
+        with patch("nexus.upgrade_finish.os.kill") as k, \
+                patch("nexus.upgrade_finish.subprocess.run") as sp:
             actions = restart_stale(self._report(), dry_run=True)
+        sp.assert_not_called()
         k.assert_not_called()
         assert any("would restart aspect-worker" in a for a in actions)
         assert any("NEEDS HUMAN: mcp-host" in a for a in actions)
 
     def test_kills_worker_reports_session_bound(self):
-        with patch("nexus.upgrade_finish.os.kill") as k:
+        import signal  # noqa: PLC0415 — file pattern: deferred imports
+        from unittest.mock import MagicMock  # noqa: PLC0415 — file pattern: deferred imports
+
+        # Pre-kill re-verification (review 38b7db3d High-3): the probe must
+        # see OUR command at that pid, else the kill is skipped.
+        probe = MagicMock(returncode=0, stdout=(
+            "/u/.local/share/uv/tools/conexus/bin/python3 "
+            "/u/.local/bin/nx daemon aspect-worker start\n"
+        ))
+        with patch("nexus.upgrade_finish.os.kill") as k, \
+                patch("nexus.upgrade_finish.subprocess.run", return_value=probe):
             actions = restart_stale(self._report())
-        k.assert_called_once_with(200, 15)
+        k.assert_called_once_with(200, signal.SIGTERM)
         assert any("restarted aspect-worker" in a for a in actions)
         # MCP hosts are NEVER killed — a live Claude session owns them.
         assert any("pid 100" in a and "NEEDS HUMAN" in a for a in actions)
@@ -157,3 +169,46 @@ class TestVersionTransition:
         # Stamp still advanced: the transition is consumed, not retried
         # forever against a broken probe.
         assert (tmp_path / "last_seen_version").read_text().strip() == "6.7.1"
+
+
+class TestRecycledPid:
+    def test_recycled_pid_is_never_signaled(self):
+        """High-3: the pid re-verification sees a DIFFERENT command at the
+        snapshot's pid (recycled) — the kill must be skipped."""
+        from unittest.mock import MagicMock  # noqa: PLC0415 — file pattern: deferred imports
+
+        r = SkewReport(installed_version="6.8.0")
+        r.stale = [StaleProcess(pid=200, kind="aspect-worker", command="w", age_s=9)]
+        probe = MagicMock(returncode=0, stdout="/usr/bin/vim innocent.txt\n")
+        with patch("nexus.upgrade_finish.os.kill") as k, \
+                patch("nexus.upgrade_finish.subprocess.run", return_value=probe):
+            actions = restart_stale(r)
+        k.assert_not_called()
+        assert any("gone or recycled" in a for a in actions)
+
+
+class TestFailLoud:
+    def test_missing_dist_info_raises(self, tmp_path):
+        """Critical-1: an unlocatable dist-info must RAISE, never degrade to
+        mtime=0.0 (which silently disabled ALL skew detection)."""
+        import pytest as _pytest  # noqa: PLC0415 — file pattern: deferred imports
+        from unittest.mock import MagicMock  # noqa: PLC0415 — file pattern: deferred imports
+
+        from nexus.upgrade_finish import install_mtime_and_version  # noqa: PLC0415 — file pattern: deferred imports
+
+        dist = MagicMock()
+        dist.version = "6.8.0"
+        dist.locate_file.return_value = tmp_path  # no dist-info inside
+        with patch("importlib.metadata.distribution", return_value=dist), \
+                _pytest.raises(RuntimeError, match="dist-info"):
+            install_mtime_and_version()
+
+    def test_ps_failure_raises(self):
+        """M5: a failed/empty ps must RAISE, never read as zero processes."""
+        import pytest as _pytest  # noqa: PLC0415 — file pattern: deferred imports
+        from unittest.mock import MagicMock  # noqa: PLC0415 — file pattern: deferred imports
+
+        bad = MagicMock(returncode=1, stdout="", stderr="boom")
+        with patch("nexus.upgrade_finish.subprocess.run", return_value=bad), \
+                _pytest.raises(RuntimeError, match="ps failed"):
+            enumerate_processes(None)

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "6.7.1"
+version = "6.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## conexus 6.8.0

Two UX arcs from live dogfooding of 6.7.x:

- **Chunk quarantine (soft delete)**: the orphan GC moves orphans to per-origin prefix-excluded siblings instead of hard-deleting (or nagging); auto-restore on re-reference; grace-window expiry is the only hard delete, floor-guarded. Doctor/ETL/legacy-gc treat quarantine state as expected. First RDR-156 soft-delete piece.
- **Finish-the-upgrade**: version-transition auto-trigger in nx + both MCP hosts (safe daemon restarts, drain-polled, venv-scoped so dev checkouts never touch production), `nx daemon restart-stale`, doctor "Process freshness" check, uv-receipt source reporting.
- README surfaces the RDR-182 diagnostics/recovery feature.

### Gates (all green on this tree)
Full pytest 13,151 · local-service gate PASSED 475/33 · sandbox smoke done · engine floor green (cloud 0.1.41 == floor, no cloud-relevant service drift) · both arcs stacked-reviewed with all findings actioned (10 Criticals total caught and fixed pre-merge).

Details in CHANGELOG.md 6.8.0.