### PR TITLE
release: conexus 6.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v6.9.0"
+        "ref": "v6.10.0"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "6.9.0"
+      "version": "6.10.0"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v6.9.0"
+        "ref": "v6.10.0"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "6.9.0"
+      "version": "6.10.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,73 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.10.0] - 2026-07-15
+
+Taxonomy curation goes unattended, bibliographic metadata finally reaches
+the catalog rows every browsing surface reads, and a boot crash-loop on
+upgraded installs is fixed engine-side. Ships with (and requires)
+engine-service-v0.1.43.
+
+### Added
+
+- **`nx taxonomy review --auto`** (nexus-vfs67, nexus-6i01g): batched,
+  unattended topic review — swaps the interactive judge for
+  `claude_dispatch` verdicts (accept / rename / delete / merge, keyed by
+  real topic id). accept/rename apply immediately; delete/merge print a
+  grouped destructive plan gated on confirmation or `--yes`; `--dry-run`
+  applies nothing. Merge guards: self-merge, missing target,
+  cross-collection target, target-deleted-this-run, and
+  target-is-a-merge-source-this-run (prevents same-run merge-chain
+  assignment orphaning). Per-item fault-tolerant apply loops with a
+  `failed` counter in the summary. Productizes the validated 2026-07-14
+  manual pass (524 topics, 0 errors).
+- **Catalog bibliographic metadata surfacing** (nexus-9l2lg, nexus-6ha8a):
+  `nx enrich bib` now writes `bib_year` / `bib_authors` / `bib_venue` /
+  `bib_citation_count` (+ backend ids, DOI, `bib_enriched_at`) to the
+  matching catalog Document rows — previously the catalog's bib columns
+  (RDR-101) had no writer at all, so `catalog_search` / `catalog_list` /
+  `nx catalog show` always showed them empty. Every browsing-surface
+  reader now carries all 8 bib columns (both local and service backends),
+  the event-sourced write path (default-ON) persists and carry-forwards
+  them at all four emission sites, and `nx catalog show` prints them.
+  New **`nx enrich bib --backfill-catalog`** re-drives the catalog write
+  from already-enriched chunk metadata — zero external API calls,
+  idempotent, honest skip counts.
+
+### Fixed
+
+- **Engine boot crash-loop on foreign-owned relations** (GH #1402,
+  nexus-0gis0; engine-side fix in engine-service-v0.1.43, which this
+  release pins): `grants-nexus-svc-1`'s bulk `GRANT ... ON ALL TABLES`
+  hard-errored as `nexus_admin` on the deliberately superuser-owned
+  `diag_chash_conformance` view, aborting every engine boot once the
+  view exists. Grants are now per-relation and owner-restricted, with a
+  boot-time NOTICE naming anything skipped. A changelog-wide conformance
+  test prevents the class from returning (third incident:
+  nexus-1wjmq, nexus-46yy3, GH #1402).
+- **Taxonomy topic_links orphaning on the SQLite leg** (nexus-y17x9):
+  every topic-deletion site (rebuild clear, `delete_topic`,
+  `merge_topics`, memory-deletion purge) now clears `topic_links`
+  explicitly — the connection runs with foreign keys off and the PG
+  cascade has no SQLite equivalent, so links silently orphaned (~6.9k
+  in the pre-migration store).
+- **Service-mode `nx taxonomy status` reported "0 topic links"**
+  (nexus-ntkr5): the link count now uses the public link-pairs API
+  instead of a hardcoded 0 (7,518 live links were invisible).
+- **Chash-probe fallback log no longer asserts "view absent"** as the
+  cause (nexus-0gis0): the view path also fails on grant/ownership gaps;
+  the note now points at the error field instead of guessing — the old
+  hardcoded guess misled the GH #1402 field diagnosis.
+
+### Changed
+
+- **`REQUIRED_ENGINE_VERSION` floor: 0.1.43** (fix-delivery rule — the
+  GH #1402 grants fix ships to local installs only via this floor/pin;
+  `PINNED_SERVICE_TAG` moves with it by construction).
+- **MinerU upgrade behavior documented** (nexus-s2rl1, wontfix-by-design):
+  upgrades cycle a running MinerU but never cold-start an absent one —
+  on-demand spawn covers first use; `nx mineru start` pre-warms.
+
 ## [6.9.0] - 2026-07-14
 
 MinerU becomes self-healing, catalog search stops being blind to the files

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the conexus plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.10.0] - 2026-07-15
+
+Plugin version aligned with conexus 6.10.0. No plugin-side changes; see
+the root CHANGELOG for `nx taxonomy review --auto`, catalog bibliographic
+metadata surfacing, and the GH #1402 engine boot fix in this release.
+
 ## [6.9.0] - 2026-07-14
 
 Plugin version aligned with conexus 6.9.0. No plugin-side changes; see the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -874,6 +874,10 @@ nx taxonomy list                                # topic tree
 nx taxonomy list -c docs__nexus                 # topic tree for one collection
 nx taxonomy show 5                              # docs assigned to topic 5
 nx taxonomy review                              # interactive: accept/rename/merge/delete/skip
+nx taxonomy review --auto                       # unattended: batched claude_dispatch verdicts
+nx taxonomy review --auto --dry-run             # preview verdicts, apply nothing
+nx taxonomy review --auto --yes                 # skip the destructive-action confirm prompt
+nx taxonomy review --auto --batch-size 20       # topics per claude_dispatch call (default 40)
 nx taxonomy label                               # batch-relabel with Claude haiku
 nx taxonomy assign doc-id "topic label"         # manually assign a doc
 nx taxonomy rename "old label" "new label"      # rename a topic
@@ -891,6 +895,55 @@ nx taxonomy validate-refs docs/**/*.md                        # stale-reference 
 nx taxonomy backfill-source-collection                        # dry-run: backfill legacy source_collection rows
 nx taxonomy backfill-source-collection --apply                # commit the backfill (irreversible)
 ```
+
+### `nx taxonomy review --auto`
+
+Unattended alternative to the interactive judge: batches pending topics
+(`--batch-size`, default 40) and asks `claude_dispatch` for a verdict per
+topic — `accept` / `rename` / `delete` / `merge` — using the same rubric a
+human reviewer would apply (specific-coherent label -> accept; coherent
+cluster with a bad label -> rename; syntax pattern-pollution such as
+pytest/monkeypatch scaffolding, Java test boilerplate, license/import
+headers, CSS blobs, or home-directory path fragments -> delete;
+near-duplicate of another topic -> merge into its real topic id).
+
+```
+nx taxonomy review --auto                       # default: up to 5000 pending topics
+nx taxonomy review --auto -c docs__nexus         # scope to one collection
+nx taxonomy review --auto --limit 200            # cap topics considered
+nx taxonomy review --auto --batch-size 20        # topics per claude_dispatch call
+nx taxonomy review --auto --dry-run              # print verdicts, apply nothing
+nx taxonomy review --auto --yes                  # skip the destructive-action confirm prompt
+```
+
+`accept` and `rename` apply immediately (unless `--dry-run`, which suppresses
+every mutation including those). `delete` and `merge` are held and printed as
+a grouped destructive plan — topic id, label, doc count, and the model's
+one-line reason for deletes; source label -> target label and doc counts for
+merges — then applied only after an interactive `y/N` confirm or `--yes`.
+Declining leaves those topics pending.
+
+Fail-open throughout: a `claude_dispatch` exception, a malformed response, or
+an invalid verdict entry leaves that topic pending rather than raising.
+Verdicts are matched back to topics by their real id, not list position, so a
+model response cannot be misapplied to the wrong topic. Merge verdicts are
+additionally guard-validated once the whole batch is known — self-merge, a
+target that is itself a merge source in the same run (the same-run
+merge-chain guard: dropping this is what prevents a same-run `A->B, B->C`
+chain from silently orphaning `A`'s doc assignments onto an already-deleted
+`B`), a missing target, a target in a different collection, or a target that
+was itself verdict-deleted this run all drop the merge (topic stays pending)
+rather than applying it. Each destructive apply is independently
+fault-tolerant — one delete or merge raising does not abort the rest of the
+batch; it is counted as failed and logged, and remaining actions still apply.
+A closing summary line reports exact counts: accepted, renamed, deleted,
+merged, skipped (declined, fail-open, and guard-dropped), and failed
+(apply-time errors).
+
+`--limit` defaults to 15 for interactive review and 5000 for `--auto` —
+pass `--limit` explicitly to override either mode. Dispatch is sequential,
+one batch at a time; parallel dispatch is an explicit non-goal for this
+version (nexus-6i01g).
 
 ### `nx taxonomy validate-refs`
 
@@ -933,7 +986,7 @@ taxonomy:
 | `discover` | Discover topics via HDBSCAN. `--all` for all collections, `-c NAME` for one, `--force` to re-cluster |
 | `list` | Topic tree with doc counts. `-c NAME` filters by collection, `-d N` sets tree depth (default: 2) |
 | `show ID` | Documents assigned to a topic. `-n N` limits results (default: 20) |
-| `review` | Interactive review: accept, rename, merge, delete, skip. `-c NAME` to filter, `-n N` topics per session (default: 15) |
+| `review` | Interactive review: accept, rename, merge, delete, skip. `-c NAME` to filter, `-n N` topics per session (default: 15). `--auto` swaps in batched `claude_dispatch` verdicts (default limit 5000); `--yes` skips the destructive-action confirm, `--dry-run` applies nothing, `--batch-size N` sets topics per dispatch (default: 40) |
 | `label` | Batch-relabel topics with Claude haiku. `--all` relabels accepted topics too |
 | `assign DOC LABEL` | Manually assign a doc to a topic by label. `-c NAME` scopes label lookup |
 | `rename OLD NEW` | Rename a topic. `-c NAME` scopes label lookup |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2182,6 +2182,14 @@ during extraction. An explicit non-local `pdf.mineru_server_url` is never
 shadowed by a local spawn, and `nx mineru start` (the explicit verb) is
 never gated.
 
+**Upgrades do not start MinerU.** The post-upgrade process sweep only
+*cycles* a MinerU server it finds running (so a stale binary is replaced);
+a server that was not running at upgrade time stays absent — by design,
+since the on-demand spawn above covers first use. The trade-off is that the
+first post-upgrade PDF extraction pays the full cold start (model warm-up,
+possibly a model download). Run `nx mineru start` after an upgrade if you
+want the server warm before the first extraction touches it.
+
 ### nx mineru start
 
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -430,6 +430,11 @@ For each unique `source_title` in the collection: extracts DOI / arXiv ID from c
 | `--source {semantic-scholar\|openalex}` | Bibliographic backend (default: `semantic-scholar`) |
 | `--delay SECONDS` | Delay between API calls (default: 0.5s). Increase to avoid rate limiting |
 | `--limit N` | Maximum number of titles to enrich (default: 0 = unlimited) |
+| `--backfill-catalog` | Re-drive the catalog write from ALREADY-enriched chunk metadata — no external API calls. Populates the catalog Document rows' `bib_*` fields (surfaced by `catalog_search` / `catalog_list` / `nx catalog show`) for collections enriched before those columns had a writer. Idempotent; titles whose chunks carry bib metadata but have no matching catalog row are reported separately as skipped |
+
+Enrichment also writes the same bib fields to the matching **catalog**
+Document rows (year, authors, venue, citation count, backend id), so
+`catalog_search`, `catalog_list`, and `nx catalog show` surface them.
 
 **Note**: Semantic Scholar's public API allows 100 requests per 5 minutes without an API key. OpenAlex is unauthenticated but encourages including a contact email via `pyalex.config.email`. For large collections, increase `--delay` or use `--limit` to process in batches. DOI extraction prefers labeled DOIs (`DOI: 10.x/y`) over bare DOI strings to avoid contamination from cited references.
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "6.9.0"
+version = "6.10.0"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=6.9.0",
+    "conexus[local]>=6.10.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "6.9.0"
+version = "6.10.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/service/src/main/resources/db/changelog/grants-nexus-svc.xml
+++ b/service/src/main/resources/db/changelog/grants-nexus-svc.xml
@@ -55,19 +55,71 @@
             loudly and migration aborts (fail-fast — no silent skip).
             runAlways: re-executed on every startup so a role created after the first
             migration is automatically provisioned on the next restart.
+            Owner-restricted per-relation iteration (nexus-46yy3 class, GH #1402,
+            nexus-0gis0): the bulk GRANT ... ON ALL TABLES/SEQUENCES form hard-errors on
+            any relation this role (nexus_admin, NOSUPERUSER) does not own — specifically
+            the deliberately superuser-owned nexus.diag_chash_conformance view (RLS-exempt
+            owner required, nexus-vounk) — aborting every engine boot once the view
+            exists. Foreign-owned relations are intentionally skipped: nexus_svc does not
+            need access to them, and only their owner can grant on them anyway.
         </comment>
-        <sql splitStatements="false">
+        <sql splitStatements="false" stripComments="false">
 -- Schema usage
 GRANT USAGE ON SCHEMA nexus TO nexus_svc;
 GRANT USAGE ON SCHEMA t1    TO nexus_svc;
 
--- DML on all existing tables in both schemas
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES    IN SCHEMA nexus TO nexus_svc;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES    IN SCHEMA t1    TO nexus_svc;
+DO $$
+DECLARE
+    rel RECORD;
+    skipped_count integer;
+    skipped_names text;
+BEGIN
+    -- DML + sequence usage on every relation THIS role owns (nexus_admin
+    -- created the schema, so this covers every table/view/sequence in
+    -- normal operation). Foreign-owned relations (e.g. the superuser-owned
+    -- diag_chash_conformance view) are skipped by construction — nexus_svc
+    -- does not need them.
+    FOR rel IN
+        SELECT n.nspname, c.relname, c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname IN ('nexus', 't1')
+          AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+          AND pg_get_userbyid(c.relowner) = current_user
+    LOOP
+        IF rel.relkind = 'S' THEN
+            EXECUTE format(
+                'GRANT USAGE, SELECT ON %I.%I TO nexus_svc', rel.nspname, rel.relname
+            );
+        ELSE
+            EXECUTE format(
+                'GRANT SELECT, INSERT, UPDATE, DELETE ON %I.%I TO nexus_svc',
+                rel.nspname, rel.relname
+            );
+        END IF;
+    END LOOP;
 
--- Sequence usage (BIGSERIAL id columns)
-GRANT USAGE, SELECT                  ON ALL SEQUENCES IN SCHEMA nexus TO nexus_svc;
-GRANT USAGE, SELECT                  ON ALL SEQUENCES IN SCHEMA t1    TO nexus_svc;
+    -- Operator visibility (review finding): a foreign-owned relation is
+    -- skipped BY DESIGN — only its owner can grant on it, and nexus_svc does
+    -- not need the diag view today. But a deployment that ever drifts from
+    -- the nexus_admin-owns-everything contract (e.g. a future
+    -- superuser-provisioned object nexus_svc DOES need) would otherwise fail
+    -- silently at first query instead of visibly at boot. NOTICE, not
+    -- WARNING: skip is by design, not an error.
+    SELECT count(*), string_agg(n.nspname || '.' || c.relname, ', ')
+    INTO skipped_count, skipped_names
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname IN ('nexus', 't1')
+      AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+      AND pg_get_userbyid(c.relowner) != current_user;
+
+    IF skipped_count > 0 THEN
+        RAISE NOTICE 'grants-nexus-svc-1: skipped % foreign-owned relation(s), not granted to nexus_svc (only their owner can grant): %',
+            skipped_count, skipped_names;
+    END IF;
+END
+$$;
 
 -- Default privileges: future tables/sequences created by the schema owner automatically
 -- carry the same grants for nexus_svc (self-healing for new migrations).

--- a/service/src/test/java/dev/nexus/service/ChangelogBulkGrantConformanceTest.java
+++ b/service/src/test/java/dev/nexus/service/ChangelogBulkGrantConformanceTest.java
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Class-level tripwire for the bulk-GRANT/REVOKE ownership hazard
+ * (nexus-46yy3 class): {@code ON ALL TABLES}, {@code ON ALL SEQUENCES}, and
+ * {@code ON ALL FUNCTIONS} hard-error on any relation the acting role does
+ * not own, aborting the whole changeset. This is the THIRD grants/ownership
+ * incident in this subsystem (see grants-nexus-diag-2 / nexus-46yy3, and
+ * grants-nexus-svc-1 / GH #1402, nexus-0gis0) — every future occurrence must
+ * be either owner-restricted per-relation iteration or explicitly justified
+ * and allowlisted here.
+ *
+ * <p>{@code ALTER DEFAULT PRIVILEGES ... ON TABLES/SEQUENCES} statements are
+ * a different, safe construct (they configure future grants, not an
+ * immediate bulk operation across existing relations) and are exempted
+ * per-STATEMENT (not per-body — a {@code <sql>} block containing both a safe
+ * {@code ALTER DEFAULT PRIVILEGES} statement and an unguarded bulk grant
+ * elsewhere must still flag the latter).
+ */
+class ChangelogBulkGrantConformanceTest {
+
+    private static final Pattern BULK_GRANT_PATTERN =
+        Pattern.compile("\\bON ALL (TABLES|SEQUENCES|FUNCTIONS)\\b", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern ALTER_DEFAULT_PRIVILEGES_PATTERN =
+        Pattern.compile("ALTER DEFAULT PRIVILEGES", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Matches the opening {@code <sql} / {@code <sql ...>} tag ONLY — a
+     * trailing whitespace or {@code >} boundary excludes sibling Liquibase
+     * tags that merely share the "sql" prefix: {@code <sqlCheck>} (used by
+     * {@code <preConditions>} in grants-nexus-diag.xml and the
+     * fk-00[23]-validate.xml / catalog-013 changesets) and {@code <sqlFile
+     * .../>} (zero uses today — see
+     * {@link #noSqlFileIncludesPresent_untilScannerReadsThem()}). Neither has
+     * a whitespace-or-{@code >} character immediately after "sql" ("C" / "F"
+     * respectively), so this pattern never opens an SQL-body region for
+     * them. Without this boundary a precondition's {@code <sqlCheck>} would
+     * flip {@code inSql} true and — because {@code </sqlCheck>} does not
+     * match the closing check either — leak that state through subsequent
+     * {@code <comment>} prose until the file's next real {@code </sql>},
+     * causing false positives on comment text that merely discusses bulk
+     * grants (review finding, GH #1402 follow-up).
+     */
+    private static final Pattern OPEN_SQL_TAG = Pattern.compile("<sql[\\s>]");
+
+    /** Matches a {@code <sqlFile>} include tag, self-closing or not. */
+    private static final Pattern SQL_FILE_TAG = Pattern.compile("<sqlFile[\\s>/]");
+
+    /**
+     * (filename, changeset id) pairs allowed to keep a bulk
+     * GRANT/REVOKE-ON-ALL statement. Each entry must be independently
+     * verified — see the per-entry rationale below — not merely present.
+     */
+    private static final Set<String> ALLOWLISTED_FILES = Set.of("grants-nexus-diag.xml");
+
+    @Test
+    void noUnguardedBulkGrantOutsideAllowlist() throws IOException, URISyntaxException {
+        Path changelogDir = changelogResourceDir();
+        List<String> violations = new ArrayList<>();
+
+        try (var walk = Files.walk(changelogDir)) {
+            for (Path file : walk.filter(p -> p.toString().endsWith(".xml")).toList()) {
+                String filename = file.getFileName().toString();
+                violations.addAll(
+                    scanForUnguardedBulkGrants(filename, Files.readAllLines(file)));
+            }
+        }
+
+        assertThat(violations).as("unguarded bulk GRANT/REVOKE statements").isEmpty();
+    }
+
+    /**
+     * Cheapest sound posture for {@code <sqlFile>} includes (review finding,
+     * GH #1402 follow-up): this scanner reads .xml source text directly and
+     * has no mechanism to resolve or read a {@code <sqlFile path="..."/>}
+     * target, so any SQL hidden behind such an include is invisible to it.
+     * Rather than silently under-scanning, the MERE PRESENCE of a {@code
+     * <sqlFile>} tag anywhere under {@code db/changelog/} fails this test
+     * until the scanner is extended to read sqlFile targets. There are zero
+     * uses today; this assertion keeps it that way (or forces a scanner
+     * upgrade the day a real use appears).
+     */
+    @Test
+    void noSqlFileIncludesPresent_untilScannerReadsThem() throws IOException, URISyntaxException {
+        Path changelogDir = changelogResourceDir();
+        List<String> offenders = new ArrayList<>();
+
+        try (var walk = Files.walk(changelogDir)) {
+            for (Path file : walk.filter(p -> p.toString().endsWith(".xml")).toList()) {
+                offenders.addAll(
+                    scanForSqlFileIncludes(file.getFileName().toString(),
+                        Files.readAllLines(file)));
+            }
+        }
+
+        assertThat(offenders)
+            .as("a <sqlFile> include appeared under db/changelog/ — extend "
+                + "ChangelogBulkGrantConformanceTest to read sqlFile targets "
+                + "before using them; it is currently blind to SQL hidden "
+                + "behind sqlFile includes")
+            .isEmpty();
+    }
+
+    /**
+     * Review regression (GH #1402 follow-up): a {@code <sqlCheck>}
+     * precondition must not leak {@code inSql} state into subsequent
+     * {@code <comment>} prose. Synthetic changeset: a sqlCheck precondition,
+     * then a comment mentioning "ON ALL TABLES" prose, then a real
+     * {@code <sql>} body with no bulk grant. Must NOT flag.
+     */
+    @Test
+    void sqlCheckPrecondition_doesNotLeakIntoSubsequentCommentProse() {
+        List<String> synthetic = List.of(
+            "<changeSet id=\"synthetic-1\" author=\"test\">",
+            "    <preConditions onFail=\"MARK_RAN\">",
+            "        <sqlCheck expectedResult=\"0\">",
+            "            SELECT count(*) FROM pg_class WHERE relname = 'x'",
+            "        </sqlCheck>",
+            "    </preConditions>",
+            "    <comment>",
+            "        Unlike grants-nexus-svc-1's old form, this changeset never uses",
+            "        GRANT ... ON ALL TABLES IN SCHEMA — that prose is discussion only.",
+            "    </comment>",
+            "    <sql splitStatements=\"false\">",
+            "GRANT USAGE ON SCHEMA nexus TO nexus_svc;",
+            "    </sql>",
+            "</changeSet>");
+
+        assertThat(scanForUnguardedBulkGrants("synthetic.xml", synthetic))
+            .as("sqlCheck precondition + comment prose must not false-positive")
+            .isEmpty();
+    }
+
+    /**
+     * Companion positive case: a real {@code <sql>} body containing an
+     * unguarded bulk grant, in a file NOT on the allowlist, must still flag.
+     */
+    @Test
+    void realSqlBody_withUnguardedBulkGrant_flags() {
+        List<String> synthetic = List.of(
+            "<changeSet id=\"synthetic-2\" author=\"test\">",
+            "    <sql splitStatements=\"false\">",
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus TO nexus_svc;",
+            "    </sql>",
+            "</changeSet>");
+
+        assertThat(scanForUnguardedBulkGrants("synthetic.xml", synthetic))
+            .as("an unguarded bulk grant in a real <sql> body must be flagged")
+            .hasSize(1);
+    }
+
+    /**
+     * Case evasion (review finding): PostgreSQL keywords are
+     * case-insensitive — a lowercase bulk grant must still be flagged.
+     */
+    @Test
+    void lowercaseBulkGrant_flags() {
+        List<String> synthetic = List.of(
+            "<changeSet id=\"synthetic-3\" author=\"test\">",
+            "    <sql splitStatements=\"false\">",
+            "grant select, insert, update, delete on all tables in schema nexus to nexus_svc;",
+            "    </sql>",
+            "</changeSet>");
+
+        assertThat(scanForUnguardedBulkGrants("synthetic.xml", synthetic))
+            .as("lowercase bulk grant must still be flagged (PG keywords are case-insensitive)")
+            .hasSize(1);
+    }
+
+    /**
+     * Line-split evasion (review finding): a newline between "ON ALL" and
+     * "TABLES" must not slip a per-line matcher. The scanner accumulates
+     * each {@code <sql>} body into a single whitespace-collapsed string
+     * before matching.
+     */
+    @Test
+    void reflowedMultilineBulkGrant_flags() {
+        List<String> synthetic = List.of(
+            "<changeSet id=\"synthetic-4\" author=\"test\">",
+            "    <sql splitStatements=\"false\">",
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL",
+            "TABLES IN SCHEMA nexus TO nexus_svc;",
+            "    </sql>",
+            "</changeSet>");
+
+        assertThat(scanForUnguardedBulkGrants("synthetic.xml", synthetic))
+            .as("a bulk grant statement split across lines must still be flagged")
+            .hasSize(1);
+    }
+
+    /**
+     * Companion to {@link #noSqlFileIncludesPresent_untilScannerReadsThem()}:
+     * confirms the detector itself catches a synthetic {@code <sqlFile>} tag
+     * regardless of attribute order or self-closing form.
+     */
+    @Test
+    void sqlFilePresence_synthetic_isDetected() {
+        List<String> synthetic = List.of(
+            "<changeSet id=\"synthetic-5\" author=\"test\">",
+            "    <sqlFile path=\"db/changelog/sql/some-grant.sql\" splitStatements=\"false\"/>",
+            "</changeSet>");
+
+        assertThat(scanForSqlFileIncludes("synthetic.xml", synthetic))
+            .as("a <sqlFile> include must be detected")
+            .hasSize(1);
+    }
+
+    /**
+     * The one allowlisted occurrence (grants-nexus-diag.xml, changeset
+     * grants-nexus-diag-1) must still actually be gated by the view-absence
+     * preCondition that makes it safe — a view-owned-by-superuser-once-it-
+     * exists hazard the same as #1402, but here avoided by never running the
+     * bulk form once the view is present. If that gate is ever removed, this
+     * assertion (not just the presence of the filename in the allowlist)
+     * must fail.
+     */
+    @Test
+    void allowlistedOccurrence_isStillGatedByViewAbsencePrecondition() throws IOException,
+            URISyntaxException {
+        Path file = changelogResourceDir().resolve("grants-nexus-diag.xml");
+        String content = Files.readString(file);
+
+        int changesetIdx = content.indexOf("id=\"grants-nexus-diag-1\"");
+        assertThat(changesetIdx).as("grants-nexus-diag-1 changeset must exist").isNotNegative();
+
+        int nextChangesetIdx = content.indexOf("<changeSet", changesetIdx + 1);
+        String changesetBody = nextChangesetIdx > 0
+            ? content.substring(changesetIdx, nextChangesetIdx)
+            : content.substring(changesetIdx);
+
+        assertThat(changesetBody)
+            .as("grants-nexus-diag-1 must remain gated on the diag view's absence")
+            .contains("<preConditions")
+            .contains("expectedResult=\"0\"")
+            .contains("diag_chash_conformance");
+        assertThat(changesetBody)
+            .as("bulk ON ALL TABLES must still be present in the gated changeset")
+            .containsPattern(BULK_GRANT_PATTERN);
+    }
+
+    private static Path changelogResourceDir() throws URISyntaxException {
+        URL url = ChangelogBulkGrantConformanceTest.class.getResource("/db/changelog");
+        assertThat(url).as("db/changelog must be on the test classpath").isNotNull();
+        return Paths.get(url.toURI());
+    }
+
+    /**
+     * Scans {@code <sql>...</sql>} BODIES (not individual lines) for
+     * unguarded bulk GRANT/REVOKE-ON-ALL statements. Each body is
+     * accumulated across lines, whitespace-collapsed, and split into
+     * individual {@code ;}-delimited statements so that (a) a statement
+     * split across multiple lines is still detected as one unit
+     * (line-split evasion) and (b) the {@code ALTER DEFAULT PRIVILEGES}
+     * exemption applies per-STATEMENT, not per-body.
+     */
+    private static List<String> scanForUnguardedBulkGrants(String filename, List<String> lines) {
+        List<String> violations = new ArrayList<>();
+        boolean inSql = false;
+        int blockStartLine = -1;
+        StringBuilder body = new StringBuilder();
+
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
+            boolean opensHere = OPEN_SQL_TAG.matcher(line).find();
+            boolean closesHere = line.contains("</sql>");
+
+            if (opensHere && !inSql) {
+                inSql = true;
+                blockStartLine = i + 1;
+                body.setLength(0);
+                continue; // the tag line itself is not SQL content
+            }
+            if (!inSql) {
+                continue;
+            }
+            if (closesHere) {
+                violations.addAll(scanSqlBody(filename, blockStartLine, body.toString()));
+                inSql = false;
+                body.setLength(0);
+                continue;
+            }
+            body.append(line).append(' ');
+        }
+        return violations;
+    }
+
+    private static List<String> scanSqlBody(String filename, int startLine, String rawBody) {
+        List<String> violations = new ArrayList<>();
+        String collapsed = rawBody.replaceAll("\\s+", " ").trim();
+        for (String rawStatement : collapsed.split(";")) {
+            String statement = rawStatement.trim();
+            if (statement.isEmpty()) {
+                continue;
+            }
+            if (!BULK_GRANT_PATTERN.matcher(statement).find()) {
+                continue;
+            }
+            if (ALTER_DEFAULT_PRIVILEGES_PATTERN.matcher(statement).find()) {
+                continue;
+            }
+            if (ALLOWLISTED_FILES.contains(filename)) {
+                continue;
+            }
+            violations.add(filename + " (<sql> block starting line " + startLine + "): "
+                + statement + " — unguarded bulk GRANT/REVOKE ON ALL. This is the "
+                + "nexus-46yy3 / GH #1402 hazard class: bulk GRANT/REVOKE "
+                + "hard-errors on any relation the acting role does not "
+                + "own. Use per-relation, owner-restricted iteration "
+                + "(see grants-nexus-diag.xml changeset grants-nexus-diag-2 "
+                + "or grants-nexus-svc.xml changeset grants-nexus-svc-1), "
+                + "or add an explicitly-justified allowlist entry here.");
+        }
+        return violations;
+    }
+
+    private static List<String> scanForSqlFileIncludes(String filename, List<String> lines) {
+        List<String> offenders = new ArrayList<>();
+        for (int i = 0; i < lines.size(); i++) {
+            if (SQL_FILE_TAG.matcher(lines.get(i)).find()) {
+                offenders.add(filename + ":" + (i + 1));
+            }
+        }
+        return offenders;
+    }
+}

--- a/service/src/test/java/dev/nexus/service/GrantsSvcForeignOwnedRelationTest.java
+++ b/service/src/test/java/dev/nexus/service/GrantsSvcForeignOwnedRelationTest.java
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * GH #1402 / bead nexus-0gis0 — replay of the production crash-loop.
+ *
+ * <p>{@code grants-nexus-svc.xml}'s {@code grants-nexus-svc-1} changeset used
+ * the bulk {@code GRANT ... ON ALL TABLES IN SCHEMA} form. Bulk GRANT
+ * hard-errors on any relation the migration role (nexus_admin, NOSUPERUSER)
+ * cannot grant on — specifically the deliberately superuser-owned
+ * {@code nexus.diag_chash_conformance} view (RLS-exempt owner required,
+ * nexus-vounk) — aborting every engine boot once the view exists.
+ *
+ * <p>This is a recurrence of the nexus-46yy3 class: {@code grants-nexus-diag.xml}
+ * changeset {@code grants-nexus-diag-2} already converted its bulk REVOKE to
+ * per-relation, owner-restricted iteration. This test reconstructs the #1402
+ * production shape using the canonical two-phase provisioning split modeled
+ * by {@code SchemaMigratorIntegrationTest} (DBA-provisioned non-superuser
+ * owner role runs the full changelog from scratch, then a superuser-owned
+ * view is added afterward) and pins the equivalent fix for the GRANT side:
+ * {@code grants-nexus-svc-1} must skip relations it does not own rather than
+ * aborting.
+ */
+class GrantsSvcForeignOwnedRelationTest {
+
+    private static final String ADMIN_ROLE = "nexus_admin_svcgrant_replay";
+    private static final String ADMIN_PASS = "nexus_admin_svcgrant_replay_pw";
+    private static final String SVC_ROLE = "nexus_svc";
+    private static final String SVC_PASS = "nexus_svc_pass";
+
+    @Test
+    void changelogReplaysCleanly_withForeignOwnedDiagView() throws Exception {
+        try (var pg = PgContainerHelper.start();
+             Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+
+            // Phase A provisioning (DBA / Phase-5 nx step, NOT Liquibase) —
+            // the canonical two-phase split modeled by
+            // SchemaMigratorIntegrationTest: nexus_admin is a plain
+            // non-superuser role that will own every schema/table/sequence it
+            // creates; extensions are superuser-installed up front (CREATE
+            // EXTENSION requires superuser; neither vector nor pg_trgm is
+            // trusted).
+            exec(su, "CREATE ROLE " + ADMIN_ROLE + " LOGIN PASSWORD '" + ADMIN_PASS
+                + "' NOSUPERUSER NOCREATEDB NOCREATEROLE");
+            exec(su, "CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS
+                + "' NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS");
+            exec(su, "GRANT CREATE ON DATABASE postgres TO " + ADMIN_ROLE);
+            exec(su, "GRANT CREATE ON SCHEMA public TO " + ADMIN_ROLE);
+            exec(su, "CREATE EXTENSION IF NOT EXISTS vector");
+            exec(su, "CREATE EXTENSION IF NOT EXISTS pg_trgm");
+
+            // 1. Full changelog AS THE NON-SUPERUSER ADMIN ROLE, from
+            //    scratch. nexus_admin owns every relation it creates here —
+            //    the production shape, and avoids the default-privileges
+            //    cross-talk a superuser-first run would introduce (ALTER
+            //    DEFAULT PRIVILEGES applies to future objects created BY THE
+            //    EXECUTING ROLE; running as superuser first would leak
+            //    default grants onto the diag view created below).
+            liquibaseUpdate(pg.getJdbcUrl(), ADMIN_ROLE, ADMIN_PASS);
+
+            // 2. Reconstruct the #1402 production shape: pg_provision's
+            //    superuser bootstrap creates a SUPERUSER-owned counts view in
+            //    schema nexus (RLS-exempt owner required, nexus-vounk) that
+            //    the migration role can never grant on. Use the real diag
+            //    view name so this test documents the exact production
+            //    relation.
+            exec(su, "CREATE VIEW nexus.diag_chash_conformance AS SELECT 1 AS n");
+
+            // Sanity: the setup actually leaves a relation the admin role
+            // cannot grant on.
+            assertThat(count(su,
+                "SELECT count(*) FROM pg_class c JOIN pg_namespace n "
+                + "ON n.oid = c.relnamespace WHERE n.nspname = 'nexus' "
+                + "AND c.relname = 'diag_chash_conformance' "
+                + "AND pg_get_userbyid(c.relowner) <> '" + ADMIN_ROLE + "'"))
+                .as("diag view must be foreign-owned relative to the admin role")
+                .isEqualTo(1);
+
+            // 3. THE REPLAY: nexus_admin's next startup. runAlways
+            //    changesets fire again. Pre-fix (bulk GRANT ON ALL TABLES)
+            //    this throws permission-denied on the foreign-owned view,
+            //    aborting the whole update — the GH #1402 crash loop.
+            //    Post-fix (per-relation, owner-restricted iteration) it
+            //    must succeed.
+            liquibaseUpdate(pg.getJdbcUrl(), ADMIN_ROLE, ADMIN_PASS);
+
+            // 4. Post-conditions: nexus_svc got DML on an admin-owned table,
+            //    but NOT on the foreign-owned diag view — it does not need it.
+            assertThat(hasTablePriv(su, SVC_ROLE, "nexus.chunks_384", "INSERT"))
+                .as("admin-owned table must still be granted")
+                .isTrue();
+            assertThat(hasTablePriv(su, SVC_ROLE, "nexus.diag_chash_conformance", "SELECT"))
+                .as("foreign-owned relation intentionally skipped")
+                .isFalse();
+        }
+    }
+
+    /**
+     * Run the changelog on a DEDICATED connection (Liquibase leaves session
+     * state behind on the connection it flips to autoCommit=false).
+     */
+    private static void liquibaseUpdate(String url, String user, String pass) throws Exception {
+        try (Connection conn = DriverManager.getConnection(url, user, pass)) {
+            var lb = new Liquibase(
+                "db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                    new JdbcConnection(conn)));
+            lb.update(new Contexts());
+        }
+    }
+
+    private static boolean hasTablePriv(Connection c, String role, String rel, String priv)
+            throws Exception {
+        try (var ps = c.prepareStatement("SELECT has_table_privilege(?, ?, ?)")) {
+            ps.setString(1, role);
+            ps.setString(2, rel);
+            ps.setString(3, priv);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getBoolean(1);
+            }
+        }
+    }
+
+    private static int count(Connection c, String sql) throws Exception {
+        try (Statement st = c.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+
+    private static void exec(Connection c, String sql) throws Exception {
+        try (Statement st = c.createStatement()) {
+            st.execute(sql);
+        }
+    }
+}

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -453,6 +453,14 @@ class CatalogEntry:
     bib_authors: str = ""
     bib_venue: str = ""
     bib_citation_count: int = 0
+    # nexus-9l2lg: the remaining 4 of 8 RDR-101 bib_* columns. The engine
+    # (CatalogRepository) already persists and returns all 8; these were
+    # missing here, which meant every local reader silently truncated
+    # them even though the wire payload carried them.
+    bib_semantic_scholar_id: str = ""
+    bib_openalex_id: str = ""
+    bib_doi: str = ""
+    bib_enriched_at: str = ""
 
     def to_dict(self) -> dict:
         return {
@@ -475,6 +483,10 @@ class CatalogEntry:
             "bib_authors": self.bib_authors,
             "bib_venue": self.bib_venue,
             "bib_citation_count": self.bib_citation_count,
+            "bib_semantic_scholar_id": self.bib_semantic_scholar_id,
+            "bib_openalex_id": self.bib_openalex_id,
+            "bib_doi": self.bib_doi,
+            "bib_enriched_at": self.bib_enriched_at,
         }
 
 

--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -80,6 +80,56 @@ def _row_to_collection_dict(row: tuple) -> dict:
     return d
 
 
+# Full ``documents`` row shape for readers that return whole
+# CatalogEntry lists (nexus-6ha8a follow-up, critic finding 1). Every
+# reader that selects this full set shares one ``_entry_from_row``
+# constructor via the ``dict(zip(_DOC_COLUMNS, row))`` idiom, so a
+# future column addition is a one-place change instead of N
+# hand-rolled positional-index CatalogEntry constructions silently
+# drifting out of sync — the exact bug class this bead fixes (four
+# readers independently forgot to select bib_*, one of them also
+# forgot alias_of).
+_DOC_COLUMNS: tuple[str, ...] = (
+    "tumbler", "title", "author", "year", "content_type", "file_path",
+    "corpus", "physical_collection", "chunk_count", "head_hash",
+    "indexed_at", "metadata", "source_mtime", "alias_of", "source_uri",
+    "bib_year", "bib_authors", "bib_venue", "bib_citation_count",
+    "bib_semantic_scholar_id", "bib_openalex_id", "bib_doi",
+    "bib_enriched_at",
+)
+_DOC_COLUMNS_SQL = ", ".join(_DOC_COLUMNS)
+
+
+def _entry_from_row(row: dict) -> "CatalogEntry":
+    """Build a ``CatalogEntry`` from ``dict(zip(_DOC_COLUMNS, sql_row))``."""
+    from nexus.catalog.catalog import CatalogEntry  # noqa: PLC0415 — circular-dep avoidance: deferred intra-package import
+    return CatalogEntry(
+        tumbler=Tumbler.parse(row["tumbler"]),
+        title=row["title"] or "",
+        author=row["author"] or "",
+        year=row["year"] or 0,
+        content_type=row["content_type"] or "",
+        file_path=row["file_path"] or "",
+        corpus=row["corpus"] or "",
+        physical_collection=row["physical_collection"] or "",
+        chunk_count=row["chunk_count"] or 0,
+        head_hash=row["head_hash"] or "",
+        indexed_at=row["indexed_at"] or "",
+        meta=json.loads(row["metadata"]) if row.get("metadata") else {},
+        source_mtime=row["source_mtime"] or 0.0,
+        alias_of=row["alias_of"] or "",
+        source_uri=row["source_uri"] or "",
+        bib_year=row["bib_year"] or 0,
+        bib_authors=row["bib_authors"] or "",
+        bib_venue=row["bib_venue"] or "",
+        bib_citation_count=row["bib_citation_count"] or 0,
+        bib_semantic_scholar_id=row["bib_semantic_scholar_id"] or "",
+        bib_openalex_id=row["bib_openalex_id"] or "",
+        bib_doi=row["bib_doi"] or "",
+        bib_enriched_at=row["bib_enriched_at"] or "",
+    )
+
+
 class _DocumentOps:
     """Read-only catalog queries composed onto ``Catalog``.
 
@@ -108,7 +158,8 @@ class _DocumentOps:
             "SELECT tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
             "metadata, source_mtime, alias_of, source_uri, "
-            "bib_year, bib_authors, bib_venue, bib_citation_count "
+            "bib_year, bib_authors, bib_venue, bib_citation_count, "
+            "bib_semantic_scholar_id, bib_openalex_id, bib_doi, bib_enriched_at "
             "FROM documents WHERE tumbler = ?",
             (str(target),),
         ).fetchone()
@@ -135,6 +186,11 @@ class _DocumentOps:
             bib_authors=row[16] or "",
             bib_venue=row[17] or "",
             bib_citation_count=row[18] or 0,
+            # nexus-9l2lg: the remaining 4 of 8 bib_* columns.
+            bib_semantic_scholar_id=row[19] or "",
+            bib_openalex_id=row[20] or "",
+            bib_doi=row[21] or "",
+            bib_enriched_at=row[22] or "",
         )
 
     def list_by_collection(
@@ -485,7 +541,8 @@ class _DocumentOps:
             "SELECT tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
             "metadata, source_mtime, alias_of, source_uri, "
-            "bib_year, bib_authors, bib_venue, bib_citation_count "
+            "bib_year, bib_authors, bib_venue, bib_citation_count, "
+            "bib_semantic_scholar_id, bib_openalex_id, bib_doi, bib_enriched_at "
             "FROM documents WHERE tumbler LIKE ?",
             (prefix + ".%",),
         ).fetchall()
@@ -510,6 +567,12 @@ class _DocumentOps:
                 "bib_authors": r[16] or "",
                 "bib_venue": r[17] or "",
                 "bib_citation_count": r[18] or 0,
+                # nexus-9l2lg: the remaining 4 of 8 bib_* columns — closes
+                # the nexus-u26b4 parity gap with HttpCatalogClient.descendants().
+                "bib_semantic_scholar_id": r[19] or "",
+                "bib_openalex_id": r[20] or "",
+                "bib_doi": r[21] or "",
+                "bib_enriched_at": r[22] or "",
             }
             for r in rows
         ]
@@ -564,6 +627,16 @@ class _DocumentOps:
                 indexed_at=r["indexed_at"] or "",
                 meta=json.loads(r["metadata"]) if r.get("metadata") else {},
                 source_mtime=r["source_mtime"] if "source_mtime" in r else 0.0,
+                # nexus-9l2lg: surface bib_* on FTS search results (nx
+                # catalog search / Catalog.find()).
+                bib_year=r.get("bib_year") or 0,
+                bib_authors=r.get("bib_authors") or "",
+                bib_venue=r.get("bib_venue") or "",
+                bib_citation_count=r.get("bib_citation_count") or 0,
+                bib_semantic_scholar_id=r.get("bib_semantic_scholar_id") or "",
+                bib_openalex_id=r.get("bib_openalex_id") or "",
+                bib_doi=r.get("bib_doi") or "",
+                bib_enriched_at=r.get("bib_enriched_at") or "",
             )
             for r in rows
         ]
@@ -573,7 +646,10 @@ class _DocumentOps:
         from nexus.catalog.catalog import CatalogEntry  # noqa: PLC0415 — circular-dep avoidance: deferred intra-package import
         row = cat._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime, source_uri "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+            "metadata, source_mtime, source_uri, "
+            "bib_year, bib_authors, bib_venue, bib_citation_count, "
+            "bib_semantic_scholar_id, bib_openalex_id, bib_doi, bib_enriched_at "
             f"FROM documents WHERE {cat._prefix_sql(str(owner))[0]} AND file_path = ?",
             (*cat._prefix_sql(str(owner))[1], file_path),
         ).fetchone()
@@ -594,6 +670,17 @@ class _DocumentOps:
             meta=json.loads(row[11]) if row[11] else {},
             source_mtime=row[12] or 0.0,
             source_uri=row[13] or "",
+            # nexus-9l2lg: by_file_path was missing ALL 8 bib_* columns
+            # (a reader gap the design/plan audit didn't catch — resolve()
+            # and descendants() were the only readers named).
+            bib_year=row[14] or 0,
+            bib_authors=row[15] or "",
+            bib_venue=row[16] or "",
+            bib_citation_count=row[17] or 0,
+            bib_semantic_scholar_id=row[18] or "",
+            bib_openalex_id=row[19] or "",
+            bib_doi=row[20] or "",
+            bib_enriched_at=row[21] or "",
         )
 
     def by_source_uri(self, uri: str) -> CatalogEntry | None:
@@ -635,76 +722,30 @@ class _DocumentOps:
 
     def by_owner(self, owner: Tumbler) -> list[CatalogEntry]:
         cat = self._cat
-        from nexus.catalog.catalog import CatalogEntry  # noqa: PLC0415 — circular-dep avoidance: deferred intra-package import
         rows = cat._db.execute(
-            "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime, source_uri "
+            f"SELECT {_DOC_COLUMNS_SQL} "
             f"FROM documents WHERE {cat._prefix_sql(str(owner))[0]}",
             cat._prefix_sql(str(owner))[1],
         ).fetchall()
-        return [
-            CatalogEntry(
-                tumbler=Tumbler.parse(r[0]),
-                title=r[1],
-                author=r[2],
-                year=r[3],
-                content_type=r[4],
-                file_path=r[5],
-                corpus=r[6],
-                physical_collection=r[7],
-                chunk_count=r[8],
-                head_hash=r[9],
-                indexed_at=r[10],
-                meta=json.loads(r[11]) if r[11] else {},
-                source_mtime=r[12] or 0.0,
-                source_uri=r[13] or "",
-            )
-            for r in rows
-        ]
+        return [_entry_from_row(dict(zip(_DOC_COLUMNS, r))) for r in rows]
 
     def by_content_type(self, content_type: str) -> list[CatalogEntry]:
         """List all entries with the given content type (code, paper, rdr, knowledge)."""
         cat = self._cat
-        from nexus.catalog.catalog import CatalogEntry  # noqa: PLC0415 — circular-dep avoidance: deferred intra-package import
         rows = cat._db.execute(
-            "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime, source_uri "
-            "FROM documents WHERE content_type = ?",
+            f"SELECT {_DOC_COLUMNS_SQL} FROM documents WHERE content_type = ?",
             (content_type,),
         ).fetchall()
-        return [
-            CatalogEntry(
-                tumbler=Tumbler.parse(r[0]), title=r[1], author=r[2], year=r[3],
-                content_type=r[4], file_path=r[5], corpus=r[6],
-                physical_collection=r[7], chunk_count=r[8], head_hash=r[9],
-                indexed_at=r[10], meta=json.loads(r[11]) if r[11] else {},
-                source_mtime=r[12] or 0.0,
-                source_uri=r[13] or "",
-            )
-            for r in rows
-        ]
+        return [_entry_from_row(dict(zip(_DOC_COLUMNS, r))) for r in rows]
 
     def by_corpus(self, corpus: str) -> list[CatalogEntry]:
         """List all entries with the given corpus tag."""
         cat = self._cat
-        from nexus.catalog.catalog import CatalogEntry  # noqa: PLC0415 — circular-dep avoidance: deferred intra-package import
         rows = cat._db.execute(
-            "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime, source_uri "
-            "FROM documents WHERE corpus = ?",
+            f"SELECT {_DOC_COLUMNS_SQL} FROM documents WHERE corpus = ?",
             (corpus,),
         ).fetchall()
-        return [
-            CatalogEntry(
-                tumbler=Tumbler.parse(r[0]), title=r[1], author=r[2], year=r[3],
-                content_type=r[4], file_path=r[5], corpus=r[6],
-                physical_collection=r[7], chunk_count=r[8], head_hash=r[9],
-                indexed_at=r[10], meta=json.loads(r[11]) if r[11] else {},
-                source_mtime=r[12] or 0.0,
-                source_uri=r[13] or "",
-            )
-            for r in rows
-        ]
+        return [_entry_from_row(dict(zip(_DOC_COLUMNS, r))) for r in rows]
 
     def doc_count(self) -> int:
         """Return the total number of documents in the catalog."""
@@ -731,16 +772,11 @@ class _DocumentOps:
         HttpCatalogClient (which already supported offset).
         """
         cat = self._cat
-        from nexus.catalog.catalog import CatalogEntry  # noqa: PLC0415 — circular-dep avoidance: deferred intra-package import
-        # alias_of at position 13 — required so verify_cmd's alias filter is non-vacuous.
-        # Without alias_of in the SELECT, CatalogEntry.alias_of defaults to "" for every
-        # row and the `not e.alias_of` guard in verify_cmd is vacuously True (nexus-xnz0o).
-        sql = (
-            "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, "
-            "source_mtime, alias_of, source_uri "
-            "FROM documents"
-        )
+        # alias_of is in _DOC_COLUMNS — required so verify_cmd's alias filter
+        # is non-vacuous. Without alias_of in the SELECT, CatalogEntry.alias_of
+        # defaults to "" for every row and the `not e.alias_of` guard in
+        # verify_cmd is vacuously True (nexus-xnz0o).
+        sql = f"SELECT {_DOC_COLUMNS_SQL} FROM documents"
         params: tuple = ()
         if content_type:
             sql += " WHERE content_type = ?"
@@ -750,18 +786,7 @@ class _DocumentOps:
         if offset > 0:
             sql += f" OFFSET {offset}"
         rows = cat._db.execute(sql, params).fetchall()
-        return [
-            CatalogEntry(
-                tumbler=Tumbler.parse(r[0]), title=r[1], author=r[2], year=r[3],
-                content_type=r[4], file_path=r[5], corpus=r[6],
-                physical_collection=r[7], chunk_count=r[8], head_hash=r[9],
-                indexed_at=r[10], meta=json.loads(r[11]) if r[11] else {},
-                source_mtime=r[12] or 0.0,
-                alias_of=r[13] or "",
-                source_uri=r[14] or "",
-            )
-            for r in rows
-        ]
+        return [_entry_from_row(dict(zip(_DOC_COLUMNS, r))) for r in rows]
 
     def by_doc_id(self, doc_id: str) -> CatalogEntry | None:
         """Look up catalog entry by T3 doc_id stored in meta.doc_id."""

--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -107,7 +107,9 @@ class _WriteOps:
         row = cat._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-            "metadata, source_mtime, source_uri, alias_of "
+            "metadata, source_mtime, source_uri, alias_of, "
+            "bib_year, bib_authors, bib_venue, bib_citation_count, "
+            "bib_semantic_scholar_id, bib_openalex_id, bib_doi, bib_enriched_at "
             "FROM documents WHERE tumbler = ?",
             (tumbler,),
         ).fetchone()
@@ -138,6 +140,19 @@ class _WriteOps:
                 indexed_at=row[10] or "",
                 alias_of=row[14] or "",
                 meta=dict(meta_dict),
+                # nexus-6ha8a: carry the row's current bib_* forward —
+                # this is a collection re-point, not a bib change; the
+                # event-sourced projector's ON CONFLICT SET clause
+                # writes these verbatim, so omitting them would clobber
+                # any prior enrichment.
+                bib_year=int(row[15] or 0),
+                bib_authors=row[16] or "",
+                bib_venue=row[17] or "",
+                bib_citation_count=int(row[18] or 0),
+                bib_semantic_scholar_id=row[19] or "",
+                bib_openalex_id=row[20] or "",
+                bib_doi=row[21] or "",
+                bib_enriched_at=row[22] or "",
             ),
             v=0,
         )
@@ -157,6 +172,14 @@ class _WriteOps:
             "source_mtime": row[12] or 0.0,
             "source_uri": row[13] or "",
             "alias_of": row[14] or "",
+            "bib_year": row[15] or 0,
+            "bib_authors": row[16] or "",
+            "bib_venue": row[17] or "",
+            "bib_citation_count": row[18] or 0,
+            "bib_semantic_scholar_id": row[19] or "",
+            "bib_openalex_id": row[20] or "",
+            "bib_doi": row[21] or "",
+            "bib_enriched_at": row[22] or "",
         }
         if cat._event_sourced_enabled:
             cat._write_to_event_log(event)
@@ -443,6 +466,19 @@ class _WriteOps:
                 # ``entry.alias_of`` directly, silently dropping the
                 # caller-supplied value.
                 "alias_of": entry.alias_of or "",
+                # nexus-9l2lg: carry bib_* forward from the current row so
+                # an update() that doesn't pass bib kwargs preserves them
+                # (clobber protection flips from omission to carry-through;
+                # explicit bib_* kwargs below still override via the
+                # generic ``rec_dict.update(fields)`` merge).
+                "bib_year": entry.bib_year,
+                "bib_authors": entry.bib_authors,
+                "bib_venue": entry.bib_venue,
+                "bib_citation_count": entry.bib_citation_count,
+                "bib_semantic_scholar_id": entry.bib_semantic_scholar_id,
+                "bib_openalex_id": entry.bib_openalex_id,
+                "bib_doi": entry.bib_doi,
+                "bib_enriched_at": entry.bib_enriched_at,
             }
             # Merge meta dict rather than replace
             if "meta" in fields and isinstance(fields["meta"], dict):
@@ -530,6 +566,22 @@ class _WriteOps:
                     indexed_at=rec_dict["indexed_at"],
                     alias_of=rec_dict["alias_of"],
                     meta=dict(rec_dict["meta"]),
+                    # nexus-6ha8a: bib_* sourced from rec_dict, which
+                    # already carries the current row's values forward
+                    # (nexus-9l2lg Task 2) unless the caller passed
+                    # explicit bib_* kwargs, in which case those win via
+                    # the rec_dict.update(fields) merge above. This is
+                    # the emission-site carry-forward the projector's
+                    # ON CONFLICT SET clause depends on to avoid
+                    # clobbering bib_* on replay.
+                    bib_year=int(rec_dict["bib_year"] or 0),
+                    bib_authors=rec_dict["bib_authors"],
+                    bib_venue=rec_dict["bib_venue"],
+                    bib_citation_count=int(rec_dict["bib_citation_count"] or 0),
+                    bib_semantic_scholar_id=rec_dict["bib_semantic_scholar_id"],
+                    bib_openalex_id=rec_dict["bib_openalex_id"],
+                    bib_doi=rec_dict["bib_doi"],
+                    bib_enriched_at=rec_dict["bib_enriched_at"],
                 ),
                 v=0,
             )
@@ -538,7 +590,8 @@ class _WriteOps:
                 # overloaded (source_uri rename, bib enrichment, etc.);
                 # the lossless DocumentRegistered-with-post-update-state
                 # captures everything via the projector's INSERT OR
-                # REPLACE. Future Phase 3+ work may introduce
+                # REPLACE (nexus-6ha8a: including bib_*, carried forward
+                # above). Future Phase 3+ work may introduce
                 # fine-grained DocumentRenamed/DocumentEnriched events
                 # that capture intent rather than state.
                 cat._write_to_event_log(event)
@@ -559,22 +612,26 @@ class _WriteOps:
                 # no cascade fires.
                 #
                 # NOTE: the SET clause lists every column that
-                # ``cat.update()`` is expected to refresh. ``bib_*``
-                # columns are intentionally NOT in the list — under the
-                # prior ``INSERT OR REPLACE`` form, every catalog
-                # update implicitly reset bibliographic enrichment to
-                # the column defaults (because REPLACE deletes-and-
-                # re-inserts), which silently lost any ``nx enrich``
-                # data on every re-index. ON CONFLICT DO UPDATE
-                # preserves the pre-existing bib_* values: the only
-                # writer to those columns becomes the explicit
-                # ``BibliographicEnriched`` event handler.
+                # ``cat.update()`` is expected to refresh, including
+                # ``bib_*`` (nexus-9l2lg). Clobber protection is
+                # carry-through, not omission: ``rec_dict`` was seeded
+                # from the current row's ``entry.bib_*`` values above,
+                # so a caller that doesn't pass bib kwargs writes back
+                # the same values that were already there; a caller
+                # that does pass ``bib_year=...`` etc. overrides via
+                # the generic ``rec_dict.update(fields)`` merge. This
+                # replaces the prior protection-by-omission, which
+                # deferred to a "BibliographicEnriched event handler"
+                # that was never built.
                 cat._db.execute(
                     "INSERT INTO documents "
                     "(tumbler, title, author, year, content_type, file_path, "
                     "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-                    "metadata, source_mtime, source_uri, alias_of) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                    "metadata, source_mtime, source_uri, alias_of, "
+                    "bib_year, bib_authors, bib_venue, bib_citation_count, "
+                    "bib_semantic_scholar_id, bib_openalex_id, bib_doi, bib_enriched_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+                    "?, ?, ?, ?, ?, ?, ?, ?) "
                     "ON CONFLICT(tumbler) DO UPDATE SET "
                     "title=excluded.title, author=excluded.author, "
                     "year=excluded.year, content_type=excluded.content_type, "
@@ -583,7 +640,14 @@ class _WriteOps:
                     "chunk_count=excluded.chunk_count, head_hash=excluded.head_hash, "
                     "indexed_at=excluded.indexed_at, metadata=excluded.metadata, "
                     "source_mtime=excluded.source_mtime, "
-                    "source_uri=excluded.source_uri, alias_of=excluded.alias_of",
+                    "source_uri=excluded.source_uri, alias_of=excluded.alias_of, "
+                    "bib_year=excluded.bib_year, bib_authors=excluded.bib_authors, "
+                    "bib_venue=excluded.bib_venue, "
+                    "bib_citation_count=excluded.bib_citation_count, "
+                    "bib_semantic_scholar_id=excluded.bib_semantic_scholar_id, "
+                    "bib_openalex_id=excluded.bib_openalex_id, "
+                    "bib_doi=excluded.bib_doi, "
+                    "bib_enriched_at=excluded.bib_enriched_at",
                     (
                         rec_dict["tumbler"], rec_dict["title"], rec_dict["author"],
                         rec_dict["year"], rec_dict["content_type"], rec_dict["file_path"],
@@ -594,6 +658,11 @@ class _WriteOps:
                         rec_dict.get("source_mtime", 0.0),
                         rec_dict.get("source_uri", ""),
                         rec_dict["alias_of"],
+                        rec_dict["bib_year"], rec_dict["bib_authors"],
+                        rec_dict["bib_venue"], rec_dict["bib_citation_count"],
+                        rec_dict["bib_semantic_scholar_id"],
+                        rec_dict["bib_openalex_id"], rec_dict["bib_doi"],
+                        rec_dict["bib_enriched_at"],
                     ),
                 )
                 cat._db.commit()
@@ -622,19 +691,21 @@ class _WriteOps:
             rows = cat._db.execute(
                 "SELECT tumbler, title, author, year, content_type, file_path, "
                 "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-                "metadata, source_mtime, source_uri, alias_of "
+                "metadata, source_mtime, source_uri, alias_of, "
+                "bib_year, bib_authors, bib_venue, bib_citation_count, "
+                "bib_semantic_scholar_id, bib_openalex_id, bib_doi, bib_enriched_at "
                 "FROM documents WHERE physical_collection = ?",
                 (old,),
             ).fetchall()
             from nexus.catalog.synthesizer import _owner_prefix_of as _opo  # noqa: PLC0415 — deferred to avoid circular import
             for row in rows:
-                # Preserve source_mtime + source_uri + alias_of across
-                # the rename — JSONL is the rebuild source of truth, so
-                # any column omitted here is reset to its default when
-                # Catalog.rebuild() replays the log (review finding —
-                # Reviewer B/C1, nexus-1ccq follow-up; RDR-096 P3.1
-                # extended this to source_uri; meta-review extended it
-                # to alias_of).
+                # Preserve source_mtime + source_uri + alias_of + bib_*
+                # across the rename — JSONL is the rebuild source of
+                # truth, so any column omitted here is reset to its
+                # default when Catalog.rebuild() replays the log (review
+                # finding — Reviewer B/C1, nexus-1ccq follow-up; RDR-096
+                # P3.1 extended this to source_uri; meta-review extended
+                # it to alias_of; nexus-6ha8a extended it to bib_*).
                 rec = {
                     "tumbler": row[0],
                     "title": row[1],
@@ -651,6 +722,14 @@ class _WriteOps:
                     "source_mtime": row[12] or 0.0,
                     "source_uri": row[13] or "",
                     "alias_of": row[14] or "",
+                    "bib_year": row[15] or 0,
+                    "bib_authors": row[16] or "",
+                    "bib_venue": row[17] or "",
+                    "bib_citation_count": row[18] or 0,
+                    "bib_semantic_scholar_id": row[19] or "",
+                    "bib_openalex_id": row[20] or "",
+                    "bib_doi": row[21] or "",
+                    "bib_enriched_at": row[22] or "",
                 }
                 if cat._event_sourced_enabled:
                     # Per-row event-source: write event, project to
@@ -678,6 +757,16 @@ class _WriteOps:
                             indexed_at=row[10] or "",
                             alias_of=row[14] or "",
                             meta=dict(meta_dict),
+                            # nexus-6ha8a: carry current bib_* forward —
+                            # a rename must not clobber enrichment.
+                            bib_year=int(row[15] or 0),
+                            bib_authors=row[16] or "",
+                            bib_venue=row[17] or "",
+                            bib_citation_count=int(row[18] or 0),
+                            bib_semantic_scholar_id=row[19] or "",
+                            bib_openalex_id=row[20] or "",
+                            bib_doi=row[21] or "",
+                            bib_enriched_at=row[22] or "",
                         ),
                         v=0,
                     )
@@ -740,6 +829,17 @@ class _WriteOps:
                             indexed_at=row[10] or "",
                             alias_of=row[14] or "",
                             meta=dict(meta_dict),
+                            # nexus-6ha8a: carry current bib_* forward —
+                            # shadow-emitted events must not disagree
+                            # with live SQLite on replay.
+                            bib_year=int(row[15] or 0),
+                            bib_authors=row[16] or "",
+                            bib_venue=row[17] or "",
+                            bib_citation_count=int(row[18] or 0),
+                            bib_semantic_scholar_id=row[19] or "",
+                            bib_openalex_id=row[20] or "",
+                            bib_doi=row[21] or "",
+                            bib_enriched_at=row[22] or "",
                         ),
                         v=0,
                     ))

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -273,6 +273,27 @@ class DocumentRegisteredPayload:
     indexed_at: str = ""
     alias_of: str = ""
     meta: dict[str, Any] = field(default_factory=dict)
+    # nexus-6ha8a: RDR-101 bib_* columns, added after this payload type
+    # already existed — same pattern as ``alias_of``/``source_uri`` before
+    # it. Defaults (0/"") apply when an OLDER event (written before this
+    # field existed) is replayed: ``Event.from_dict`` filters the parsed
+    # JSON to declared fields, so a legacy payload missing these keys
+    # constructs with the defaults rather than raising. This means a full
+    # cold replay of a pre-existing event log reproduces bib_year=0/etc.
+    # for any document whose LAST DocumentRegistered-type event predates
+    # this change and was never re-touched afterward — the live LOCAL
+    # apply path (an event emitted now, with current values carried
+    # forward from the live row) is unaffected. See catalog_writes.py's
+    # emission sites (update, rename_collection x2,
+    # _update_document_collection_locked) for the carry-forward writers.
+    bib_year: int = 0
+    bib_authors: str = ""
+    bib_venue: str = ""
+    bib_citation_count: int = 0
+    bib_semantic_scholar_id: str = ""
+    bib_openalex_id: str = ""
+    bib_doi: str = ""
+    bib_enriched_at: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -196,6 +196,13 @@ def _to_entry(d: dict) -> CatalogEntry:
         bib_authors=d.get("bib_authors") or "",
         bib_venue=d.get("bib_venue") or "",
         bib_citation_count=d.get("bib_citation_count") or 0,
+        # nexus-9l2lg: the remaining 4 of 8 bib_* columns — the wire dict
+        # already carries these (CatalogRepository.docRowFromRecord), this
+        # was a pure mapping gap.
+        bib_semantic_scholar_id=d.get("bib_semantic_scholar_id") or "",
+        bib_openalex_id=d.get("bib_openalex_id") or "",
+        bib_doi=d.get("bib_doi") or "",
+        bib_enriched_at=d.get("bib_enriched_at") or "",
     )
 
 

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -233,18 +233,40 @@ class Projector:
         # every projector replay (INSERT OR REPLACE deletes-then-inserts
         # the row, triggering the cascade; ON CONFLICT DO UPDATE updates
         # in place). The SET clause lists exactly the columns that
-        # ``DocumentRegistered`` payloads carry; ``bib_*`` columns are
-        # intentionally absent so projector replay does not clobber
-        # bibliographic enrichment written by the
-        # ``BibliographicEnriched`` event handler — a behavioural
-        # divergence from the prior INSERT OR REPLACE which reset bib_*
-        # to defaults on every replay.
+        # ``DocumentRegistered`` payloads carry.
+        #
+        # nexus-6ha8a: ``bib_*`` columns are now included. This is safe
+        # ONLY because all 4 ``DocumentRegisteredPayload`` emission sites
+        # for EXISTING documents (``update()``, both ``rename_collection``
+        # sites, ``_update_document_collection_locked``) carry the row's
+        # CURRENT bib_* values forward into the payload — mirroring how
+        # ``source_mtime``/``source_uri``/``alias_of`` are already
+        # preserved. Naively wiring this SET clause without that
+        # carry-forward would have clobbered bib_* on every plain
+        # collection rename; that was the nexus-9l2lg Task 5 finding this
+        # bead (nexus-6ha8a) resolved.
+        #
+        # Replay caveat: an event written BEFORE this field existed has
+        # no ``bib_*`` keys in its serialized JSON; ``Event.from_dict``
+        # filters to declared fields, so it constructs with the payload's
+        # 0/"" defaults (events.py). A full cold replay of a pre-existing
+        # event log therefore reproduces bib_year=0/etc. for any document
+        # whose LAST ``DocumentRegistered``-type event predates this
+        # change and was never re-touched afterward — the live apply path
+        # (an event emitted now, applied now) is unaffected. This is the
+        # same class of exposure ``alias_of``/``source_uri`` already carry
+        # (fields added to this payload type after it existed); not solved
+        # here, matching that existing posture.
         self._db.execute(
             "INSERT INTO documents "
             "(tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, "
-            "indexed_at, metadata, source_mtime, alias_of, source_uri) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "indexed_at, metadata, source_mtime, alias_of, source_uri, "
+            "bib_year, bib_authors, bib_venue, bib_citation_count, "
+            "bib_semantic_scholar_id, bib_openalex_id, bib_doi, "
+            "bib_enriched_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+            "?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(tumbler) DO UPDATE SET "
             "title=excluded.title, author=excluded.author, "
             "year=excluded.year, content_type=excluded.content_type, "
@@ -253,7 +275,14 @@ class Projector:
             "chunk_count=excluded.chunk_count, head_hash=excluded.head_hash, "
             "indexed_at=excluded.indexed_at, metadata=excluded.metadata, "
             "source_mtime=excluded.source_mtime, alias_of=excluded.alias_of, "
-            "source_uri=excluded.source_uri",
+            "source_uri=excluded.source_uri, "
+            "bib_year=excluded.bib_year, bib_authors=excluded.bib_authors, "
+            "bib_venue=excluded.bib_venue, "
+            "bib_citation_count=excluded.bib_citation_count, "
+            "bib_semantic_scholar_id=excluded.bib_semantic_scholar_id, "
+            "bib_openalex_id=excluded.bib_openalex_id, "
+            "bib_doi=excluded.bib_doi, "
+            "bib_enriched_at=excluded.bib_enriched_at",
             (
                 tumbler,
                 payload.title,
@@ -274,6 +303,14 @@ class Projector:
                 payload.source_mtime,
                 payload.alias_of,
                 payload.source_uri,
+                payload.bib_year,
+                payload.bib_authors,
+                payload.bib_venue,
+                payload.bib_citation_count,
+                payload.bib_semantic_scholar_id,
+                payload.bib_openalex_id,
+                payload.bib_doi,
+                payload.bib_enriched_at,
             ),
         )
 

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -482,6 +482,18 @@ def show_cmd(tumbler_or_title: str, as_json: bool) -> None:
         click.echo(f"Chunks:     {entry.chunk_count}")
         click.echo(f"Hash:       {entry.head_hash}")
         click.echo(f"Indexed:    {entry.indexed_at}")
+        # nexus-6ha8a follow-up: resolve() has carried bib_* since
+        # nexus-9l2lg, but this plain-text branch never printed them.
+        # Conditional on non-empty/non-zero, matching the URI line's
+        # convention above.
+        if entry.bib_year:
+            click.echo(f"Bib Year:    {entry.bib_year}")
+        if entry.bib_authors:
+            click.echo(f"Bib Authors: {entry.bib_authors}")
+        if entry.bib_venue:
+            click.echo(f"Bib Venue:   {entry.bib_venue}")
+        if entry.bib_citation_count:
+            click.echo(f"Citations:   {entry.bib_citation_count}")
         out_links = cat.links_from(entry.tumbler)
         in_links = cat.links_to(entry.tumbler)
         if out_links:

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
 
 import click
@@ -157,8 +158,17 @@ def enrich() -> None:
         "When DEVONthink is unavailable it degrades to ``auto`` exactly."
     ),
 )
+@click.option(
+    "--backfill-catalog",
+    is_flag=True,
+    help=(
+        "Re-drive the catalog bib_* write from already-enriched T3 "
+        "chunk metadata; no external API calls. Idempotent."
+    ),
+)
 def enrich_bib(
     collection: str, delay: float, limit: int, source: str,
+    backfill_catalog: bool,
 ) -> None:
     """Backfill bibliographic metadata for chunks in COLLECTION.
 
@@ -171,8 +181,111 @@ def enrich_bib(
 
     Already-enriched chunks (the backend's ID field is non-empty) are
     skipped — the command is idempotent per backend.
+
+    ``--backfill-catalog`` (nexus-9l2lg) skips the network path
+    entirely: it re-derives the catalog ``bib_*`` write from chunk
+    metadata that a prior live enrichment already wrote, for catalog
+    rows that predate the ``_enrich_apply`` column-level write (or
+    otherwise drifted stale). Idempotent; makes zero external calls.
     """
+    if backfill_catalog:
+        _backfill_catalog_from_chunks(collection)
+        return
     run_bib_enrichment(collection, delay=delay, limit=limit, source=source)
+
+
+def _backfill_catalog_from_chunks(collection: str) -> tuple[int, int, int]:
+    """Re-drive the catalog bib_* write from already-enriched T3 chunk
+    metadata. No external API calls — zero imports of
+    ``nexus.bib_enricher*``. Idempotent: re-running re-applies the
+    same values to the same matched rows (``titles_backfilled`` counts
+    "a catalog row was matched and updated", not "this changed since
+    last run" — a title with an already-current row still counts as
+    backfilled on every run).
+
+    nexus-6ha8a follow-up (critic finding 3): a title with enriched
+    chunk metadata but NO matching catalog row (deleted, never
+    registered, migrated away, ...) is a silent no-op at the
+    ``_catalog_enrich_hook`` layer — such titles are counted in
+    ``titles_skipped_no_row``, not ``titles_backfilled``, so the
+    summary line reports what actually changed.
+
+    Returns ``(titles_backfilled, chunks_scanned, titles_skipped_no_row)``.
+    """
+    from nexus.db import make_t3  # noqa: PLC0415 — circular-dep avoidance; command-local import
+    from nexus.retry import _chroma_with_retry  # noqa: PLC0415 — deferred command-local import; avoids import-time cost for unrelated CLI commands
+
+    db = make_t3()
+    col = db.get_or_create_collection(collection)
+
+    # One representative chunk's bib_* metadata per title — no
+    # re-lookup, no external call. Mirrors the already_enriched
+    # detection in run_bib_enrichment (an id field is non-empty).
+    title_bib: dict[str, dict] = {}
+    title_source_paths: dict[str, set[str]] = {}
+    chunks_scanned = 0
+    offset = 0
+    while True:
+        batch = _chroma_with_retry(
+            col.get, include=["metadatas"], limit=300, offset=offset,
+        )
+        batch_ids = batch.get("ids", [])
+        batch_meta = batch.get("metadatas", [])
+        chunks_scanned += len(batch_ids)
+        for meta in batch_meta:
+            s2_id = meta.get("bib_semantic_scholar_id", "") or ""
+            oa_id = meta.get("bib_openalex_id", "") or ""
+            if not (meta.get("bib_year") or s2_id or oa_id):
+                continue
+            title = meta.get("title", "") or ""
+            if not title:
+                continue
+            if title not in title_bib:
+                title_bib[title] = {
+                    "year": meta.get("bib_year", 0),
+                    "venue": meta.get("bib_venue", ""),
+                    "authors": meta.get("bib_authors", ""),
+                    "citation_count": meta.get("bib_citation_count", 0),
+                }
+                if oa_id:
+                    title_bib[title]["openalex_id"] = oa_id
+                    if meta.get("bib_doi"):
+                        title_bib[title]["doi"] = meta.get("bib_doi", "")
+                else:
+                    title_bib[title]["semantic_scholar_id"] = s2_id
+            sp = meta.get("source_path", "") or ""
+            if sp:
+                title_source_paths.setdefault(title, set()).add(sp)
+        if len(batch_ids) < 300:
+            break
+        offset += 300
+
+    titles_backfilled = 0
+    titles_skipped_no_row = 0
+    for title, bib in title_bib.items():
+        backend = "openalex" if bib.get("openalex_id") else "s2"
+        updated = _catalog_enrich_hook(
+            title=title, bib_meta=bib, collection_name=collection,
+            backend=backend,
+            source_paths=sorted(title_source_paths.get(title, set())),
+        )
+        # nexus-6ha8a follow-up (critic finding 3): _catalog_enrich_hook
+        # now reports whether it actually matched+updated a row. A
+        # title with enriched chunks but no corresponding catalog row
+        # (deleted, never registered, etc.) is a silent no-op there —
+        # count it as skipped, not backfilled, so this summary line
+        # doesn't overstate what changed.
+        if updated:
+            titles_backfilled += 1
+        else:
+            titles_skipped_no_row += 1
+
+    click.echo(
+        f"Backfilled {titles_backfilled} titles from {chunks_scanned} "
+        f"chunks in '{collection}' (no external calls); "
+        f"{titles_skipped_no_row} titles skipped (no matching catalog row)."
+    )
+    return titles_backfilled, chunks_scanned, titles_skipped_no_row
 
 
 def run_bib_enrichment(
@@ -615,13 +728,23 @@ def _catalog_enrich_hook(
     collection_name: str = "",
     backend: str = "s2",
     source_paths: list[str] | None = None,
-) -> None:
+) -> bool:
     """Update catalog entry with bib metadata. Silently skipped if absent.
 
-    nexus-57mk: ``backend`` selects which ID field is written into
-    catalog meta. The OpenAlex backend writes ``bib_openalex_id`` (and
-    ``bib_doi`` when present) so the citation-link generator can match
-    references in OpenAlex's W-id space.
+    Returns True when a catalog row was matched and updated, False on
+    any no-op (catalog not initialized, no matching row, or an
+    exception — best-effort, never raises).
+
+    nexus-57mk: ``backend`` selects which ID field is written. The
+    OpenAlex backend writes ``bib_openalex_id`` (and ``bib_doi`` when
+    present) so the citation-link generator can match references in
+    OpenAlex's W-id space.
+
+    nexus-9l2lg: ``bib_year``/``bib_authors``/``bib_venue``/
+    ``bib_citation_count``/``bib_enriched_at`` plus the backend id
+    field(s) write to the catalog Document's top-level ``bib_*``
+    columns (RDR-101) via ``writer.update(**bib_fields)`` — not the
+    ``meta`` JSON blob. ``meta`` now carries only ``references``.
 
     nexus-tv22: ``source_paths`` (the absolute paths of the chunks
     being enriched) is the authoritative way to find the catalog row.
@@ -645,7 +768,7 @@ def _catalog_enrich_hook(
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
-            return
+            return False
 
         from nexus.catalog.factory import make_catalog_reader, make_catalog_writer  # noqa: PLC0415 — circular-dep avoidance; command-local import
         reader = make_catalog_reader()
@@ -661,14 +784,21 @@ def _catalog_enrich_hook(
                 reader.close()
     except Exception:  # noqa: BLE001 — best-effort catalog enrich hook; failure logged at debug, primary enrich unaffected
         _log.debug("catalog_enrich_hook_failed", exc_info=True)
+        return False
 
 
 def _enrich_apply(
     reader, writer, collection_name, title, source_paths, bib_meta, backend, Tumbler,
-):
-    # RDR-146 P1.2: reads via the read-only reader, writes via the
-    # write-only daemon proxy. Exceptions propagate to the caller's
-    # catalog_enrich_hook_failed handler.
+) -> bool:
+    """Returns True when >=1 catalog row was matched and updated, False
+    when the hook was a silent no-op (no matching row — nexus-6ha8a
+    follow-up, critic finding 3: the caller needs this to distinguish
+    a genuine backfill from a no-op so summary counts stay honest).
+
+    RDR-146 P1.2: reads via the read-only reader, writes via the
+    write-only daemon proxy. Exceptions propagate to the caller's
+    catalog_enrich_hook_failed handler.
+    """
     target_tumblers: list[Tumbler] = []
 
     # nexus-tv22: prefer source_path match (unique per document).
@@ -741,21 +871,31 @@ def _enrich_apply(
             collection=collection_name,
             source_paths=source_paths or [],
         )
-        return
+        return False
 
     # Build the update payload once, apply to every matched row.
-    meta_update: dict = {
-        "venue": bib_meta.get("venue", ""),
-        "citation_count": bib_meta.get("citation_count", 0),
+    #
+    # nexus-9l2lg: bib_* fields write to the catalog Document's top-level
+    # bib_* columns (RDR-101), not the meta JSON blob. Nothing read venue
+    # / citation_count / the backend id fields back out of meta (verified
+    # by grep before removing) — dual storage was pure YAGNI. ``meta``
+    # keeps only ``references``, which has no catalog column.
+    bib_fields: dict = {
+        "bib_year": bib_meta.get("year", 0),
+        "bib_authors": bib_meta.get("authors", ""),
+        "bib_venue": bib_meta.get("venue", ""),
+        "bib_citation_count": bib_meta.get("citation_count", 0),
+        "bib_enriched_at": datetime.now(UTC).isoformat(),
     }
     if backend == "openalex":
-        meta_update["bib_openalex_id"] = bib_meta.get("openalex_id", "")
+        bib_fields["bib_openalex_id"] = bib_meta.get("openalex_id", "")
         if bib_meta.get("doi"):
-            meta_update["bib_doi"] = bib_meta.get("doi", "")
+            bib_fields["bib_doi"] = bib_meta.get("doi", "")
     else:
-        meta_update["bib_semantic_scholar_id"] = bib_meta.get(
+        bib_fields["bib_semantic_scholar_id"] = bib_meta.get(
             "semantic_scholar_id", "",
         )
+    meta_update: dict = {}
     refs = bib_meta.get("references", [])
     if refs:
         meta_update["references"] = refs
@@ -772,7 +912,9 @@ def _enrich_apply(
             author=bib_meta.get("authors", ""),
             year=bib_meta.get("year", 0),
             meta=meta_update,
+            **bib_fields,
         )
+    return True
 
 
 # ── nx enrich aspects (RDR-089 P2.2) ────────────────────────────────────────

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -2,6 +2,8 @@
 """CLI command group for topic taxonomy (RDR-061 P3-2, RDR-070 nexus-2dq)."""
 from __future__ import annotations
 
+import asyncio
+import json
 from typing import TYPE_CHECKING, Any
 
 import click
@@ -871,11 +873,44 @@ def _show_merge_targets(
 
 @taxonomy.command("review")
 @click.option("--collection", "-c", default="", help="Filter by collection")
-@click.option("--limit", "-n", default=15, type=int, help="Topics per session", show_default=True)
-def review_cmd(collection: str, limit: int) -> None:
+@click.option(
+    "--limit", "-n", default=None, type=int,
+    help="Topics per session (default: 15 interactive, 5000 with --auto)",
+)
+@click.option(
+    "--auto", is_flag=True,
+    help="Batched claude_dispatch verdicts instead of interactive prompts",
+)
+@click.option(
+    "--yes", "-y", is_flag=True,
+    help="Skip the destructive-action confirmation prompt (--auto only)",
+)
+@click.option(
+    "--dry-run", is_flag=True,
+    help="Print verdicts without applying any mutations (--auto only)",
+)
+@click.option(
+    "--batch-size", default=40, type=int, show_default=True,
+    help="Topics per claude_dispatch call (--auto only)",
+)
+def review_cmd(
+    collection: str,
+    limit: int | None,
+    auto: bool,
+    yes: bool,
+    dry_run: bool,
+    batch_size: int,
+) -> None:
     """Interactive topic review — accept, rename, merge, delete, or skip."""
+    resolved_limit = limit if limit is not None else (5000 if auto else 15)
+
+    if auto:
+        with _T2Database(_default_db_path()) as db:
+            _review_auto(db, collection, resolved_limit, yes, dry_run, batch_size)
+        return
+
     with _T2Database(_default_db_path()) as db:
-        topics = db.taxonomy.get_unreviewed_topics(collection=collection, limit=limit)
+        topics = db.taxonomy.get_unreviewed_topics(collection=collection, limit=resolved_limit)
         if not topics:
             click.echo("No unreviewed topics. All done!")
             return
@@ -1472,6 +1507,373 @@ async def _generate_labels_batch(
         if 0 <= slot < len(items) and 3 <= len(label) <= 60:
             results[slot] = label.strip().strip('"').strip("'")
     return results
+
+
+# ── nx taxonomy review --auto (nexus-6i01g, nexus-vfs67) ───────────────────
+
+_REVIEW_VERDICT_SCHEMA: dict = {
+    "type": "object",
+    "required": ["verdicts"],
+    "properties": {
+        "verdicts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "action"],
+                "properties": {
+                    "id": {"type": "integer", "minimum": 1},
+                    "action": {
+                        "type": "string",
+                        "enum": ["accept", "rename", "delete", "merge"],
+                    },
+                    "label": {"type": "string", "minLength": 3, "maxLength": 60},
+                    "target_id": {"type": "integer"},
+                    "reason": {"type": "string", "maxLength": 200},
+                },
+            },
+        },
+    },
+}
+
+
+async def _generate_review_verdicts_batch(
+    items: list[tuple[int, str, list[str], list[str], str]],
+) -> list[dict | None]:
+    """Generate review verdicts for a batch of topics via ``claude_dispatch``.
+
+    Each item is ``(topic_id, label, terms, sample_doc_ids, collection)``.
+    Returns one verdict dict (or ``None``, fail-open) per item, in item
+    order. Verdict shapes:
+
+    - ``{"action": "accept"}``
+    - ``{"action": "rename", "label": <3-60 chars, stripped>}``
+    - ``{"action": "delete", "reason": <str>}``
+    - ``{"action": "merge", "target_id": <int>, "reason": <str>}``
+
+    Verdicts are matched back to items by the REAL topic id (schema
+    property ``"id"``), not a positional index — a stacked-review fix
+    (nexus-6i01g finding 3): a prior version keyed by 1-based ``idx``
+    alongside a displayed ``id=`` in the prompt, two near-identical
+    numbering schemes the model could conflate, producing a
+    wrong-topic-verdict. An entry whose ``id`` is not in this batch is
+    ignored (fail-open), not misapplied to some other slot by position.
+
+    Fail-open (mirrors :func:`_generate_labels_batch`): dispatch raising
+    ANY exception, a malformed/missing ``verdicts`` key, or a per-entry
+    validation failure (bad id, unknown action, missing ``label``/
+    ``target_id`` where required) all degrade to ``None`` at that slot —
+    the caller leaves the corresponding topic pending. ``target_id``
+    guard-validation (self-merge, merge-chain same-run source/target
+    collision, missing/cross-collection target, target-deleted-this-run)
+    happens in the CLI orchestration layer, not here — this function only
+    enforces schema-shape validity.
+    """
+    if not items:
+        return []
+
+    id_to_slot = {topic_id: slot for slot, (topic_id, *_rest) in enumerate(items)}
+
+    lines = []
+    for topic_id, label, terms, doc_ids, collection in items:
+        doc_names = [d.split("/")[-1].split(":")[0][:25] for d in doc_ids[:3]]
+        lines.append(
+            f'- id={topic_id} label="{label}" terms=[{", ".join(terms[:5])}] '
+            f'docs=[{", ".join(doc_names)}] collection={collection}'
+        )
+
+    prompt = (
+        "You are reviewing topic-cluster candidates from an automated taxonomy "
+        "discovery pass. For each topic below, decide exactly one action:\n"
+        "  accept - the label is specific and coherent for the terms/docs shown.\n"
+        "  rename - the underlying cluster is coherent but the label is bad; "
+        'supply a new label (3-60 chars) as "label".\n'
+        "  delete - the topic is syntax pattern-pollution, not a real subject: "
+        "pytest/monkeypatch scaffolding, Java test boilerplate, license/import "
+        'headers, CSS blobs, home-directory path fragments. Give a one-line "reason".\n'
+        "  merge - the topic is a near-duplicate of another topic in the same "
+        "collection (usually one listed below); supply the REAL topic id (the "
+        '"id=" value) as "target_id" plus a one-line "reason".\n'
+        'Return {"verdicts": [{"id": <the id= value shown above>, '
+        '"action": "<accept|rename|delete|merge>", "label": "<if rename>", '
+        '"target_id": <if merge>, "reason": "<if delete/merge>"}, ...]} — '
+        "one entry per topic, keyed by its id (not its position in this list).\n\n"
+        + "\n".join(lines)
+    )
+
+    results: list[dict | None] = [None] * len(items)
+    try:
+        from nexus.operators.dispatch import claude_dispatch  # noqa: PLC0415 - deferred to avoid circular import at module load
+
+        payload = await claude_dispatch(prompt, _REVIEW_VERDICT_SCHEMA, timeout=180.0)
+    except Exception:  # noqa: BLE001 - best-effort payload parse; degrades to current results
+        return results
+
+    verdicts = payload.get("verdicts") if isinstance(payload, dict) else None
+    if not isinstance(verdicts, list):
+        return results
+
+    for entry in verdicts:
+        if not isinstance(entry, dict):
+            continue
+        topic_id = entry.get("id")
+        action = entry.get("action")
+        if not isinstance(topic_id, int) or not isinstance(action, str):
+            continue
+        if topic_id not in id_to_slot:
+            continue
+        slot = id_to_slot[topic_id]
+        if action == "accept":
+            results[slot] = {"action": "accept"}
+        elif action == "rename":
+            new_label = entry.get("label")
+            if isinstance(new_label, str):
+                stripped = new_label.strip()
+                if 3 <= len(stripped) <= 60:
+                    results[slot] = {"action": "rename", "label": stripped}
+        elif action == "delete":
+            reason = entry.get("reason", "")
+            results[slot] = {"action": "delete", "reason": reason if isinstance(reason, str) else ""}
+        elif action == "merge":
+            target_id = entry.get("target_id")
+            if isinstance(target_id, int):
+                reason = entry.get("reason", "")
+                results[slot] = {
+                    "action": "merge",
+                    "target_id": target_id,
+                    "reason": reason if isinstance(reason, str) else "",
+                }
+        # unknown action strings are schema-rejected upstream, but guard
+        # defensively in case a future model deviates from the enum.
+    return results
+
+
+def _print_review_destructive_plan(
+    deletes: list[dict[str, Any]], merges: list[dict[str, Any]],
+) -> None:
+    """Print a grouped, human-readable plan for pending delete/merge verdicts."""
+    click.echo("\nDestructive actions pending:")
+    if deletes:
+        click.echo(f"  Deletes ({len(deletes)}):")
+        for d in deletes:
+            reason = d.get("_reason", "")
+            click.echo(f"    [{d['id']}] {d['label']} ({d['doc_count']} docs) - {reason}")
+    if merges:
+        click.echo(f"  Merges ({len(merges)}):")
+        for m in merges:
+            reason = m.get("_reason", "")
+            click.echo(
+                f"    [{m['id']}] {m['label']} ({m['doc_count']} docs) -> "
+                f"[{m['_target_id']}] {m['_target_label']} ({m['_target_doc_count']} docs) - {reason}"
+            )
+
+
+def _review_auto(
+    db: Any,
+    collection: str,
+    limit: int,
+    yes: bool,
+    dry_run: bool,
+    batch_size: int,
+) -> None:
+    """Batched, unattended review: swaps the human judge for ``claude_dispatch``.
+
+    accept/rename apply immediately (unless ``dry_run``); delete/merge are
+    held as a destructive plan requiring ``click.confirm`` or ``--yes``
+    (``dry_run`` suppresses ALL mutations, including accept/rename).
+    Dispatch is sequential per batch — no parallelism (V1 non-goal,
+    nexus-6i01g).
+
+    Merge validation runs in a second pass once the whole batch's verdicts
+    are known (guard order documented inline below), including a CRITICAL
+    same-run merge-chain guard: a merge target that is itself a merge
+    source this run is dropped rather than applied, which would otherwise
+    risk silently orphaning assignments (``merge_topics`` has no
+    target-existence check; T2 SQLite runs with foreign keys off). Apply
+    loops additionally recheck target existence immediately before each
+    merge and wrap every ``t2_index_write`` call so one bad delete/merge
+    does not abort the remaining batch — failures are counted separately
+    from guard-dropped skips and reported in the summary line.
+    """
+    from nexus.mcp_infra import t2_index_write  # noqa: PLC0415 - deferred to avoid circular import at module load
+
+    topics = db.taxonomy.get_unreviewed_topics(collection=collection, limit=limit)
+    if not topics:
+        click.echo("No unreviewed topics. All done!")
+        return
+
+    click.echo(f"Auto-reviewing {len(topics)} topic(s) in batches of {batch_size}...")
+
+    accepted = 0
+    renamed = 0
+    skipped = 0
+    candidate_deletes: list[dict[str, Any]] = []
+    candidate_merges: list[dict[str, Any]] = []
+
+    for start in range(0, len(topics), batch_size):
+        batch = topics[start : start + batch_size]
+        items: list[tuple[int, str, list[str], list[str], str]] = []
+        for t in batch:
+            try:
+                terms = json.loads(t["terms"]) if t.get("terms") else []
+            except (json.JSONDecodeError, TypeError):
+                terms = []
+            doc_ids = db.taxonomy.get_topic_doc_ids(t["id"], limit=3)
+            items.append((t["id"], t["label"], terms, doc_ids, t["collection"]))
+
+        verdicts = asyncio.run(_generate_review_verdicts_batch(items))
+
+        for topic, verdict in zip(batch, verdicts):
+            if verdict is None:
+                skipped += 1
+                continue
+            action = verdict["action"]
+            if action == "accept":
+                if not dry_run:
+                    _tid = topic["id"]
+                    t2_index_write(lambda db, _t=_tid: db.taxonomy.mark_topic_reviewed(_t, "accepted"))
+                accepted += 1
+            elif action == "rename":
+                if not dry_run:
+                    _tid = topic["id"]
+                    _lbl = verdict["label"]
+                    t2_index_write(lambda db, _t=_tid, _l=_lbl: db.taxonomy.rename_topic(_t, _l))
+                renamed += 1
+            elif action == "delete":
+                candidate_deletes.append({**topic, "_reason": verdict.get("reason", "")})
+            elif action == "merge":
+                candidate_merges.append(
+                    {
+                        **topic,
+                        "_target_id": verdict.get("target_id"),
+                        "_reason": verdict.get("reason", ""),
+                    }
+                )
+
+    # Second pass: validate merges only once the full delete- and
+    # merge-source sets are known. Guard order (any violation: skipped += 1,
+    # topic stays pending):
+    #   1. self-merge (target_id == own id).
+    #   2. target is itself a merge SOURCE in this run. CRITICAL
+    #      (nexus-6i01g stacked-review finding 1): without this guard, a
+    #      same-run merge chain A->B, B->C can silently orphan data — if
+    #      B->C applies before A->B, merge_topics(A, B) runs against an
+    #      already-deleted B. CatalogTaxonomy.merge_topics has no
+    #      target-existence check and T2 SQLite has foreign keys OFF (no
+    #      ``PRAGMA foreign_keys=ON``), so A's assignments would silently
+    #      become orphaned rows pointing at a deleted topic_id. Dropping
+    #      any merge whose target is also a source is deterministic
+    #      regardless of apply order: A->B always drops, B->C always
+    #      proceeds (subject to its own guards).
+    #   3. target does not exist.
+    #   4. target is in a different collection.
+    #   5. target was itself verdict-deleted this run.
+    delete_ids = {d["id"] for d in candidate_deletes}
+    merge_source_ids = {m["id"] for m in candidate_merges}
+    pending_merges: list[dict[str, Any]] = []
+    for m in candidate_merges:
+        target_id = m["_target_id"]
+        if target_id == m["id"]:
+            skipped += 1
+            continue
+        if target_id in merge_source_ids:
+            skipped += 1
+            continue
+        target = db.taxonomy.get_topic_by_id(target_id)
+        if target is None:
+            skipped += 1
+            continue
+        if target["collection"] != m["collection"]:
+            skipped += 1
+            continue
+        if target_id in delete_ids:
+            skipped += 1
+            continue
+        pending_merges.append(
+            {
+                **m,
+                "_target_label": target["label"],
+                "_target_doc_count": target["doc_count"],
+            }
+        )
+
+    if dry_run:
+        if candidate_deletes or pending_merges:
+            _print_review_destructive_plan(candidate_deletes, pending_merges)
+        click.echo(
+            f"\nDry run: {accepted} would be accepted, {renamed} would be renamed, "
+            f"{len(candidate_deletes)} would be deleted, {len(pending_merges)} would be merged, "
+            f"{skipped} skipped."
+        )
+        return
+
+    deleted = 0
+    merged = 0
+    failed = 0
+    if candidate_deletes or pending_merges:
+        _print_review_destructive_plan(candidate_deletes, pending_merges)
+        try:
+            proceed = yes or click.confirm("Apply the above destructive actions?")
+        except (click.Abort, EOFError):
+            proceed = False
+
+        if proceed:
+            for d in candidate_deletes:
+                _tid = d["id"]
+                try:
+                    t2_index_write(lambda db, _t=_tid: db.taxonomy.delete_topic(_t))
+                except Exception as exc:  # noqa: BLE001 - per-item apply resilience: one bad delete must not abort the batch
+                    _log.warning(
+                        "taxonomy_review_auto_apply_failed",
+                        topic_id=_tid,
+                        action="delete",
+                        error=str(exc),
+                    )
+                    click.echo(f"  Failed to delete topic {_tid}: {exc}")
+                    failed += 1
+                    continue
+                deleted += 1
+            for m in pending_merges:
+                _src = m["id"]
+                _tgt = m["_target_id"]
+                # Defensive apply-time recheck (nexus-6i01g stacked-review
+                # finding 1): the target may have been removed between
+                # second-pass validation and this apply loop (e.g. an
+                # earlier delete in THIS loop, or an external actor) —
+                # merge_topics has no target-existence check of its own.
+                if db.taxonomy.get_topic_by_id(_tgt) is None:
+                    _log.warning(
+                        "taxonomy_review_auto_apply_failed",
+                        topic_id=_src,
+                        action="merge",
+                        error=f"target {_tgt} no longer exists",
+                    )
+                    click.echo(f"  Failed to merge topic {_src} into {_tgt}: target no longer exists")
+                    failed += 1
+                    continue
+                try:
+                    t2_index_write(lambda db, _s=_src, _t=_tgt: db.taxonomy.merge_topics(_s, _t))
+                except Exception as exc:  # noqa: BLE001 - per-item apply resilience: one bad merge must not abort the batch
+                    _log.warning(
+                        "taxonomy_review_auto_apply_failed",
+                        topic_id=_src,
+                        action="merge",
+                        error=str(exc),
+                    )
+                    click.echo(f"  Failed to merge topic {_src} into {_tgt}: {exc}")
+                    failed += 1
+                    continue
+                merged += 1
+        else:
+            # Finding 6: declined destructive items must still land in the
+            # skipped bucket so the summary tally accounts for every
+            # proposed action, not just the applied ones.
+            skipped += len(candidate_deletes) + len(pending_merges)
+            click.echo("Declined; topics remain pending.")
+
+    click.echo(
+        f"\nAuto-review complete: {accepted} accepted, {renamed} renamed, "
+        f"{deleted} deleted, {merged} merged, {skipped} skipped, {failed} failed."
+    )
 
 
 def relabel_topics(

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -459,7 +459,14 @@ def status_cmd(collection: str, limit: int, summary: bool, needs_review: bool) -
                     "SELECT COUNT(*) FROM topic_links"
                 ).fetchone()[0]
         else:
-            link_count = 0  # service mode: link count not exposed via public API
+            # Service mode: count via the public link-pairs API (nexus-ntkr5 —
+            # the previous hardcoded 0 hid 7,520 live links after the first
+            # `links --refresh` run). Works on both stores: SQLite returns a
+            # dict, HttpTaxonomyStore a list; len() is shape-agnostic.
+            # raw_topics was fetched above in this same service-mode branch —
+            # reuse it rather than paying a second HTTP round-trip.
+            _ids = [t["id"] for t in raw_topics]
+            link_count = len(db.taxonomy.get_topic_link_pairs(_ids)) if _ids else 0
 
         # Apply filters
         rows = all_topics

--- a/src/nexus/db/t2/catalog.py
+++ b/src/nexus/db/t2/catalog.py
@@ -941,7 +941,10 @@ class CatalogStore:
             sql = (
                 "SELECT d.tumbler, d.title, d.author, d.year, d.content_type, "
                 "d.file_path, d.corpus, d.physical_collection, d.chunk_count, "
-                "d.head_hash, d.indexed_at, d.metadata, d.source_mtime "
+                "d.head_hash, d.indexed_at, d.metadata, d.source_mtime, "
+                "d.bib_year, d.bib_authors, d.bib_venue, d.bib_citation_count, "
+                "d.bib_semantic_scholar_id, d.bib_openalex_id, d.bib_doi, "
+                "d.bib_enriched_at "
                 "FROM documents d "
                 "JOIN documents_fts f ON d.rowid = f.rowid "
                 "WHERE documents_fts MATCH ?"
@@ -955,7 +958,13 @@ class CatalogStore:
             rows = self._conn.execute(sql, params).fetchall()
             columns = ["tumbler", "title", "author", "year", "content_type",
                         "file_path", "corpus", "physical_collection", "chunk_count",
-                        "head_hash", "indexed_at", "metadata", "source_mtime"]
+                        "head_hash", "indexed_at", "metadata", "source_mtime",
+                        # nexus-9l2lg: surface bib_* on FTS search results
+                        # (nx catalog search / Catalog.find()) — a reader
+                        # gap the design/plan audit didn't catch.
+                        "bib_year", "bib_authors", "bib_venue",
+                        "bib_citation_count", "bib_semantic_scholar_id",
+                        "bib_openalex_id", "bib_doi", "bib_enriched_at"]
             return [dict(zip(columns, row)) for row in rows]
 
     def descendants(self, prefix: str) -> list[dict[str, Any]]:

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1085,6 +1085,13 @@ class CatalogTaxonomy:
                 "SELECT collection FROM topics WHERE id = ?", (topic_id,),
             ).fetchone()
             collection = row[0] if row else None
+            # topic_links carries no ON DELETE CASCADE here and this
+            # connection runs with foreign_keys OFF, so links must be
+            # cleared explicitly (nexus-y17x9; PG cascades these).
+            self.conn.execute(
+                "DELETE FROM topic_links WHERE from_topic_id = ? OR to_topic_id = ?",
+                (topic_id, topic_id),
+            )
             self.conn.execute(
                 "DELETE FROM topic_assignments WHERE topic_id = ?", (topic_id,),
             )
@@ -1156,7 +1163,15 @@ class CatalogTaxonomy:
                 "UPDATE topics SET doc_count = ? WHERE id = ?",
                 (new_count, target_id),
             )
-            # Delete source topic
+            # Delete source topic's links, then the topic itself.
+            # topic_links carries no ON DELETE CASCADE here and this
+            # connection runs with foreign_keys OFF, so links must be
+            # cleared explicitly (nexus-y17x9; PG cascades these on the
+            # source-topic delete).
+            self.conn.execute(
+                "DELETE FROM topic_links WHERE from_topic_id = ? OR to_topic_id = ?",
+                (source_id, source_id),
+            )
             self.conn.execute("DELETE FROM topics WHERE id = ?", (source_id,))
             self.conn.commit()
         return collection
@@ -2597,7 +2612,27 @@ class CatalogTaxonomy:
             removed = cursor.rowcount
             # Drop topics in this collection that no longer have any
             # assignments. Scoped by collection so we don't disturb
-            # siblings from other projects.
+            # siblings from other projects. Their topic_links must go
+            # first: no ON DELETE CASCADE here and this connection runs
+            # with foreign_keys OFF, so a bare topics DELETE silently
+            # orphans links (nexus-y17x9) — and this path fires on every
+            # ordinary memory deletion that empties a topic.
+            self.conn.execute(
+                """
+                DELETE FROM topic_links
+                WHERE from_topic_id IN (
+                      SELECT id FROM topics
+                      WHERE collection = ?
+                        AND id NOT IN (SELECT DISTINCT topic_id FROM topic_assignments)
+                  )
+                   OR to_topic_id IN (
+                      SELECT id FROM topics
+                      WHERE collection = ?
+                        AND id NOT IN (SELECT DISTINCT topic_id FROM topic_assignments)
+                  )
+                """,
+                (project, project),
+            )
             self.conn.execute(
                 """
                 DELETE FROM topics
@@ -2773,7 +2808,18 @@ class CatalogTaxonomy:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         topic_ids: list[int] = []
         with self._lock:
-            # Clear old T2 data for this collection.
+            # Clear old T2 data for this collection. topic_links must be
+            # cleared explicitly here: the PG leg cascades them via
+            # ON DELETE CASCADE, but this SQLite connection runs with
+            # foreign_keys OFF, so a missing DELETE silently orphans links
+            # (nexus-y17x9: ~6.9k orphaned rows in the pre-migration store).
+            self.conn.execute(
+                "DELETE FROM topic_links WHERE from_topic_id IN "
+                "(SELECT id FROM topics WHERE collection = ?) "
+                "OR to_topic_id IN "
+                "(SELECT id FROM topics WHERE collection = ?)",
+                (collection_name, collection_name),
+            )
             self.conn.execute(
                 "DELETE FROM topic_assignments WHERE topic_id IN "
                 "(SELECT id FROM topics WHERE collection = ?)",

--- a/src/nexus/engine_version.py
+++ b/src/nexus/engine_version.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 #: -> (0,1,42) 2026-07-14: catalog-015 FTS filename-token fix (nexus-8gue1,
 #: the GH #1397 search blindness) + indexed_at repair provenance
 #: (nexus-p5qk8) live in the engine — the fix-delivery rule above, applied.
-REQUIRED_ENGINE_VERSION: tuple[int, int, int] = (0, 1, 42)
+REQUIRED_ENGINE_VERSION: tuple[int, int, int] = (0, 1, 43)
 
 
 def parse_engine_version(raw: str | None) -> tuple[int, int, int] | None:

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -2231,8 +2231,14 @@ def _check_migration_state(
                 _log.warning(
                     "chash_probe_view_fallback_legacy",
                     error=str(view_exc)[:200],
-                    note="diag_chash_conformance view absent (pre-A6 engine) "
-                         "— probing tables directly under the legacy grants",
+                    # GH #1402: do NOT assert the cause here — the view path
+                    # also fails on a live view when nexus_diag lacks the
+                    # owner-granted view SELECT or the view owner lost table
+                    # access (ownership fragmentation). The error field
+                    # carries the real cause.
+                    note="view-path probe failed — falling back to legacy "
+                         "direct-table statements (view absent on pre-A6 "
+                         "engines, or view/owner grant gap — see error)",
                 )
                 counts = run_diagnostic_sql(
                     legacy_chash_conformance_statements(), diag_creds,

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -55,7 +55,7 @@ RELEASE_PROPS="service/src/main/resources/META-INF/nexus/release.properties"
 # stale default fail-closes the --cold MVV at the version gate. Kept literal (it
 # names a PUBLISHED release tag, which need not equal the floor) but bumped to
 # track it; override via NEXUS_SERVICE_TAG. (nexus-v0zmv)
-COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.42}"
+COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.43}"
 for a in "$@"; do
   case "$a" in
     --with-cloud) WITH_CLOUD=1 ;;

--- a/tests/test_bib_enricher_write_back_service_mode.py
+++ b/tests/test_bib_enricher_write_back_service_mode.py
@@ -45,6 +45,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from nexus.catalog.catalog import Catalog
 from nexus.catalog.factory import _ServiceCatalogWriter
 from nexus.catalog.http_catalog_client import HttpCatalogClient
 from nexus.catalog.tumbler import Tumbler
@@ -91,6 +92,12 @@ class _State:
             "bib_authors": "",
             "bib_venue": "",
             "bib_citation_count": 0,
+            # nexus-9l2lg: the remaining 4 of 8 bib_* columns, mirroring
+            # the real CatalogRepository schema.
+            "bib_semantic_scholar_id": "",
+            "bib_openalex_id": "",
+            "bib_doi": "",
+            "bib_enriched_at": "",
         }
         base.update(fields)
         cls.documents[tumbler] = base
@@ -276,14 +283,22 @@ class TestEnrichApplyServiceModeSourcePathMatch:
         assert body["tumbler"] == "1.1.1"
         assert body["author"] == "Alice, Bob"
         assert body["year"] == 2024
-        assert body["meta"]["venue"] == "NeurIPS"
-        assert body["meta"]["citation_count"] == 42
-        assert body["meta"]["bib_semantic_scholar_id"] == "ss123"
+        # nexus-9l2lg: bib_* fields write to top-level columns, not meta.
+        assert body["bib_venue"] == "NeurIPS"
+        assert body["bib_citation_count"] == 42
+        assert body["bib_semantic_scholar_id"] == "ss123"
+        assert body["bib_year"] == 2024
+        assert body["bib_authors"] == "Alice, Bob"
+        assert body["bib_enriched_at"] != ""
+        assert "venue" not in body["meta"]
+        assert "citation_count" not in body["meta"]
+        assert "bib_semantic_scholar_id" not in body["meta"]
         # No 400 — every top-level wire key is on CatalogRepository's
         # UPDATABLE_DOC_COLUMNS whitelist.
         stored = _State.documents["1.1.1"]
         assert stored["author"] == "Alice, Bob"
         assert stored["year"] == 2024
+        assert stored["bib_semantic_scholar_id"] == "ss123"
 
     def test_openalex_backend_writes_bib_openalex_id_and_doi(self, reader, writer) -> None:
         _State.add_document(
@@ -295,10 +310,12 @@ class TestEnrichApplyServiceModeSourcePathMatch:
             _OPENALEX_BIB_META, "openalex", Tumbler,
         )
         body = _State.update_bodies[0]
-        assert body["meta"]["bib_openalex_id"] == "W999"
-        assert body["meta"]["bib_doi"] == "10.1234/foo"
+        assert body["bib_openalex_id"] == "W999"
+        assert body["bib_doi"] == "10.1234/foo"
         # S2 field must NOT appear for the openalex backend.
-        assert "bib_semantic_scholar_id" not in body["meta"]
+        assert "bib_semantic_scholar_id" not in body
+        assert "bib_openalex_id" not in body["meta"]
+        assert "bib_doi" not in body["meta"]
 
     def test_absolute_and_relative_path_variants_both_match(self, reader, writer) -> None:
         """The lookup tries (sp, sp.lstrip('/')) — an absolute source_path
@@ -388,11 +405,77 @@ class TestMetaMergeSemanticsDrift:
             reader, writer, "knowledge__delos", "Existing Meta Paper", ["existing.pdf"],
             _S2_BIB_META, "s2", Tumbler,
         )
-        stored_meta = _State.documents["1.1.1"]["metadata"]
+        stored = _State.documents["1.1.1"]
+        stored_meta = stored["metadata"]
         # This is what the LOCAL (merge-semantics) contract guarantees and what
         # every writer.update(..., meta=...) call site in this codebase assumes.
         # In service mode it currently does NOT hold — the fields below are gone.
         assert stored_meta.get("content_hash") == "abc123"
         assert stored_meta.get("custom_field") == "keep-me"
-        # The new bib fields are of course present (that part works correctly).
-        assert stored_meta.get("venue") == "NeurIPS"
+        # nexus-9l2lg: bib fields are top-level columns now, not meta —
+        # this assertion moved off ``stored_meta`` accordingly.
+        assert stored["bib_venue"] == "NeurIPS"
+
+
+class TestBibColumnDualBackendParity:
+    """Standing regression guard for the divergence class recorded as T3
+    insight ``insight-developer-dual-backend-meta-merge-semantics-
+    divergence``: a "drop-in" method identical in name/signature across
+    backends (local ``Catalog`` vs ``HttpCatalogClient``) silently
+    diverging in semantics — the same class ``TestMetaMergeSemanticsDrift``
+    above caught for ``meta=``. nexus-9l2lg's column-level bib_* write
+    (Task 3) is new surface for exactly that risk.
+    """
+
+    def test_local_and_service_backends_produce_identical_bib_columns_after_enrich_apply(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, reader, writer,
+    ) -> None:
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+        # No NEXUS_EVENT_SOURCED pin: nexus-6ha8a extended the
+        # event-sourced projector to persist bib_* too, so this parity
+        # check holds under the ambient default (ON, RDR-101 Phase 3
+        # PR ζ) as well as the legacy path.
+
+        # (a) local Catalog — reader and writer are the same object,
+        # mirroring the direct-fallback shape make_catalog_writer() uses
+        # when no T2 daemon is reachable.
+        local_dir = tmp_path / "catalog"
+        local_cat = Catalog(local_dir, local_dir / ".catalog.db")
+        local_owner = local_cat.register_owner("delos", "curator")
+        local_cat.register(
+            local_owner, "Parity Paper", content_type="paper",
+            physical_collection="knowledge__delos", file_path="parity.pdf",
+        )
+
+        # (b) service-mode — fake-server-backed HttpCatalogClient reader
+        # + _ServiceCatalogWriter-wrapped writer (module fixtures).
+        _State.add_document(
+            "1.1.1", title="Parity Paper", physical_collection="knowledge__delos",
+            file_path="parity.pdf",
+        )
+
+        bib_meta = dict(_S2_BIB_META)
+
+        _enrich_apply(
+            local_cat, local_cat, "knowledge__delos", "Parity Paper",
+            ["parity.pdf"], bib_meta, "s2", Tumbler,
+        )
+        _enrich_apply(
+            reader, writer, "knowledge__delos", "Parity Paper",
+            ["parity.pdf"], bib_meta, "s2", Tumbler,
+        )
+
+        local_entry = local_cat.find("Parity Paper")[0]
+        service_entry = reader.find("Parity Paper")[0]
+
+        def _bib_tuple(entry):
+            return (
+                entry.bib_year, entry.bib_authors, entry.bib_venue,
+                entry.bib_citation_count, entry.bib_semantic_scholar_id,
+                entry.bib_openalex_id, entry.bib_doi,
+            )
+
+        assert _bib_tuple(local_entry) == _bib_tuple(service_entry)

--- a/tests/test_catalog_bib_columns.py
+++ b/tests/test_catalog_bib_columns.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for nexus-9l2lg: surface bib metadata on catalog Document rows.
+
+``CatalogEntry`` (nexus-rzqto) and the three local readers (``resolve``,
+``descendants``, ``HttpCatalogClient._to_entry``) originally carried only
+4 of the 8 ``bib_*`` columns the engine already persists+returns
+(``bib_year``/``bib_authors``/``bib_venue``/``bib_citation_count``).
+Missing: ``bib_semantic_scholar_id``/``bib_openalex_id``/``bib_doi``/
+``bib_enriched_at``. ``_WriteOps.update()`` additionally omitted ALL 8
+``bib_*`` columns from its non-event-sourced ``INSERT ... ON CONFLICT``
+write path entirely (protection-by-omission against a never-built
+"BibliographicEnriched event handler"). This file pins the fix: all 8
+columns round-trip through ``CatalogEntry``, ``resolve()``,
+``descendants()``, and ``update()`` — with carry-through (not omission)
+as the clobber-protection mechanism.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.catalog import Catalog, CatalogEntry
+from nexus.catalog.tumbler import read_documents
+
+
+@pytest.fixture(autouse=True)
+def git_identity(monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+
+def _make_catalog(tmp_path: Path) -> tuple[Path, Catalog]:
+    catalog_dir = tmp_path / "catalog"
+    cat = Catalog.init(catalog_dir)
+    return catalog_dir, cat
+
+
+_ALL_EIGHT = {
+    "bib_year": 2020,
+    "bib_authors": "A. Author",
+    "bib_venue": "Some Venue",
+    "bib_citation_count": 5,
+    "bib_semantic_scholar_id": "ss1",
+    "bib_openalex_id": "W1",
+    "bib_doi": "10.1/x",
+    "bib_enriched_at": "2026-01-01T00:00:00Z",
+}
+
+
+class TestCatalogEntryDataclass:
+    def test_has_all_eight_bib_fields(self) -> None:
+        from nexus.catalog.tumbler import Tumbler
+
+        entry = CatalogEntry(
+            tumbler=Tumbler.parse("1.1.1"),
+            title="t", author="", year=0, content_type="", file_path="",
+            corpus="", physical_collection="", chunk_count=0, head_hash="",
+            indexed_at="",
+            **_ALL_EIGHT,
+        )
+        assert entry.bib_year == 2020
+        assert entry.bib_authors == "A. Author"
+        assert entry.bib_venue == "Some Venue"
+        assert entry.bib_citation_count == 5
+        assert entry.bib_semantic_scholar_id == "ss1"
+        assert entry.bib_openalex_id == "W1"
+        assert entry.bib_doi == "10.1/x"
+        assert entry.bib_enriched_at == "2026-01-01T00:00:00Z"
+
+        d = entry.to_dict()
+        for key, value in _ALL_EIGHT.items():
+            assert d[key] == value
+
+
+class TestResolveSurfacesAllEightBibColumns:
+    def test_local_resolve_surfaces_all_eight_bib_columns(
+        self, tmp_path: Path,
+    ) -> None:
+        _, cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        tumbler = cat.register(owner, "Bootstrapped Paper", content_type="paper")
+
+        cat._db.execute(  # epsilon-allow: bootstrap bib_* columns directly to test the reader in isolation from the writer under test
+            "UPDATE documents SET bib_year=?, bib_authors=?, bib_venue=?, "
+            "bib_citation_count=?, bib_semantic_scholar_id=?, "
+            "bib_openalex_id=?, bib_doi=?, bib_enriched_at=? WHERE tumbler=?",
+            (
+                _ALL_EIGHT["bib_year"], _ALL_EIGHT["bib_authors"],
+                _ALL_EIGHT["bib_venue"], _ALL_EIGHT["bib_citation_count"],
+                _ALL_EIGHT["bib_semantic_scholar_id"],
+                _ALL_EIGHT["bib_openalex_id"], _ALL_EIGHT["bib_doi"],
+                _ALL_EIGHT["bib_enriched_at"], str(tumbler),
+            ),
+        )
+        cat._db.commit()
+
+        entry = cat.resolve(tumbler)
+        assert entry is not None
+        for key, value in _ALL_EIGHT.items():
+            assert getattr(entry, key) == value, key
+
+
+class TestDescendantsSurfacesAllEightBibColumns:
+    def test_descendants_surfaces_all_eight_bib_columns(
+        self, tmp_path: Path,
+    ) -> None:
+        _, cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        tumbler = cat.register(owner, "Child Paper", content_type="paper")
+
+        cat._db.execute(  # epsilon-allow: bootstrap bib_* columns directly to test the reader in isolation from the writer under test
+            "UPDATE documents SET bib_year=?, bib_authors=?, bib_venue=?, "
+            "bib_citation_count=?, bib_semantic_scholar_id=?, "
+            "bib_openalex_id=?, bib_doi=?, bib_enriched_at=? WHERE tumbler=?",
+            (
+                _ALL_EIGHT["bib_year"], _ALL_EIGHT["bib_authors"],
+                _ALL_EIGHT["bib_venue"], _ALL_EIGHT["bib_citation_count"],
+                _ALL_EIGHT["bib_semantic_scholar_id"],
+                _ALL_EIGHT["bib_openalex_id"], _ALL_EIGHT["bib_doi"],
+                _ALL_EIGHT["bib_enriched_at"], str(tumbler),
+            ),
+        )
+        cat._db.commit()
+
+        prefix = str(owner)
+        rows = cat._docs.descendants(prefix)
+        matches = [r for r in rows if r["tumbler"] == str(tumbler)]
+        assert len(matches) == 1
+        row = matches[0]
+        for key, value in _ALL_EIGHT.items():
+            assert row[key] == value, key
+
+
+class TestUpdatePreservesAndSetsBibColumns:
+    """nexus-9l2lg Task 2's target: the non-event-sourced ``INSERT ... ON
+    CONFLICT`` write path. nexus-6ha8a extended the event-sourced
+    projector path to ALSO persist bib_* (see
+    test_catalog_event_sourced_mutators.py for that coverage) — this
+    class stays pinned to ``NEXUS_EVENT_SOURCED=0`` deliberately, as the
+    dedicated legacy-path parity suite proving the non-event-sourced
+    write path (still the default for fresh SQLite schemas opened
+    directly, and the path most local single-writer installs exercise)
+    independently persists bib_* correctly. ``_read_event_sourced_gate()``
+    defaults ON (RDR-101 Phase 3 PR ζ) — leaving this ambient would
+    silently switch which branch this suite exercises.
+    """
+
+    def test_update_without_bib_kwargs_preserves_existing_bib_columns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+        _, cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        tumbler = cat.register(owner, "Carried Paper", content_type="paper")
+
+        cat.update(tumbler, **_ALL_EIGHT)
+        # A subsequent update that does NOT touch bib_* must not clobber it —
+        # the regression this codebase originally (over-)protected against
+        # by omitting bib_* from the write path entirely.
+        cat.update(tumbler, chunk_count=9)
+
+        entry = cat.resolve(tumbler)
+        assert entry is not None
+        assert entry.chunk_count == 9
+        for key, value in _ALL_EIGHT.items():
+            assert getattr(entry, key) == value, key
+
+    def test_update_with_bib_kwargs_sets_all_eight_columns_exactly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+        _, cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        tumbler = cat.register(owner, "Single Update Paper", content_type="paper")
+
+        cat.update(tumbler, **_ALL_EIGHT)
+
+        entry = cat.resolve(tumbler)
+        assert entry is not None
+        for key, value in _ALL_EIGHT.items():
+            assert getattr(entry, key) == value, key
+
+    def test_update_bib_fields_survive_jsonl_append_and_replay_filter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+        _, cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        tumbler = cat.register(owner, "JSONL Paper", content_type="paper")
+
+        cat.update(tumbler, **_ALL_EIGHT)
+
+        # DocumentRecord has no bib_* fields; _filter_fields silently drops
+        # unknown keys on reconstruction. This must not raise even though
+        # rec_dict (and therefore the appended JSONL row) now carries the
+        # new keys.
+        records = read_documents(cat._documents_path)
+        assert str(tumbler) in records
+
+    def test_update_bib_columns_on_fresh_and_migrated_schema(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+        # (a) fresh schema — CREATE TABLE already ships all 8 columns.
+        _, fresh_cat = _make_catalog(tmp_path / "fresh")
+        owner = fresh_cat.register_owner("papers", "curator")
+        fresh_tumbler = fresh_cat.register(owner, "Fresh Paper", content_type="paper")
+        fresh_cat.update(fresh_tumbler, **_ALL_EIGHT)
+        fresh_entry = fresh_cat.resolve(fresh_tumbler)
+        assert fresh_entry is not None
+        for key, value in _ALL_EIGHT.items():
+            assert getattr(fresh_entry, key) == value, key
+
+        # (b) migrated schema — pre-create a legacy pre-bib ``documents``
+        # table (same fixture shape as
+        # tests/test_catalog_documents_bib_columns.py's proven
+        # TestUpgradeFromLegacySchema pattern) BEFORE the Catalog is ever
+        # constructed. CatalogStore.__init__'s ``CREATE TABLE IF NOT
+        # EXISTS`` no-ops on the pre-existing table and its inline ALTER
+        # TABLE guards add the 8 bib_* columns back — the real upgrade
+        # path a pre-nexus-knn3 install goes through. register()/update()
+        # afterwards operate on a documents table whose bib_* columns
+        # originated via ALTER, not the original CREATE TABLE.
+        legacy_dir = tmp_path / "legacy"
+        legacy_dir.mkdir()
+        db_path = legacy_dir / ".catalog.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE documents (
+                    tumbler TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    author TEXT,
+                    year INTEGER,
+                    content_type TEXT,
+                    file_path TEXT,
+                    corpus TEXT,
+                    physical_collection TEXT,
+                    chunk_count INTEGER,
+                    head_hash TEXT,
+                    indexed_at TEXT,
+                    metadata JSON,
+                    source_mtime REAL NOT NULL DEFAULT 0,
+                    alias_of TEXT NOT NULL DEFAULT '',
+                    source_uri TEXT NOT NULL DEFAULT ''
+                );
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        migrated_cat = Catalog(legacy_dir, db_path)
+        legacy_owner = migrated_cat.register_owner("papers", "curator")
+        legacy_tumbler = migrated_cat.register(
+            legacy_owner, "Legacy Paper", content_type="paper",
+        )
+        migrated_cat.update(legacy_tumbler, **_ALL_EIGHT)
+        migrated_entry = migrated_cat.resolve(legacy_tumbler)
+        assert migrated_entry is not None
+        for key, value in _ALL_EIGHT.items():
+            assert getattr(migrated_entry, key) == value, key

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -155,6 +155,53 @@ class TestRegisterAndShow:
         assert result.exit_code == 0
         assert "URI:" not in result.output
 
+    def test_show_prints_bib_fields_when_enriched(
+        self, initialized_catalog, catalog_env,
+    ):
+        """nexus-6ha8a follow-up (critic finding 2): resolve() carries
+        bib_* since nexus-9l2lg, but the plain-text ``show`` output
+        never printed them. Print when non-empty/non-zero."""
+        from nexus.catalog.tumbler import Tumbler
+
+        runner = CliRunner()
+        runner.invoke(main, [
+            "catalog", "register",
+            "--title", "Enriched Paper",
+            "--owner", "1.1",
+            "--type", "paper",
+        ])
+        initialized_catalog.update(
+            Tumbler.parse("1.1.1"),
+            bib_year=2019, bib_authors="Dana", bib_venue="OSDI",
+            bib_citation_count=314,
+        )
+        result = runner.invoke(main, ["catalog", "show", "1.1.1"])
+        assert result.exit_code == 0
+        assert "Bib Year:    2019" in result.output
+        assert "Bib Authors: Dana" in result.output
+        assert "Bib Venue:   OSDI" in result.output
+        assert "Citations:   314" in result.output
+
+    def test_show_omits_bib_fields_when_not_enriched(
+        self, initialized_catalog, catalog_env,
+    ):
+        """Un-enriched entries (bib_* at column defaults) shouldn't
+        render bib lines at all — display is conditional, matching the
+        URI line's convention."""
+        runner = CliRunner()
+        runner.invoke(main, [
+            "catalog", "register",
+            "--title", "Plain Paper",
+            "--owner", "1.1",
+            "--type", "paper",
+        ])
+        result = runner.invoke(main, ["catalog", "show", "1.1.1"])
+        assert result.exit_code == 0
+        assert "Bib Year:" not in result.output
+        assert "Bib Authors:" not in result.output
+        assert "Bib Venue:" not in result.output
+        assert "Citations:" not in result.output
+
 
 class TestListCommand:
     def test_list_entries(self, initialized_catalog, catalog_env):

--- a/tests/test_catalog_event_sourced_mutators.py
+++ b/tests/test_catalog_event_sourced_mutators.py
@@ -179,6 +179,66 @@ class TestUpdateEventSourced:
             f"original={original_at!r} refreshed={refreshed_at!r}"
         )
 
+    def test_event_sourced_update_persists_bib_kwargs(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """nexus-6ha8a (was nexus-9l2lg Task 5's deferred decision):
+        ``DocumentRegisteredPayload`` now carries all 8 ``bib_*`` fields
+        and the projector's ``_v0_document_registered`` writes them into
+        its INSERT/ON CONFLICT SET clause. ``update()``'s event-sourced
+        branch sources them from ``rec_dict``, which already carries
+        bib_* forward from the current row (nexus-9l2lg Task 2) — so a
+        caller passing ``bib_*`` kwargs under event-sourced mode now
+        persists them, matching the non-event-sourced path.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "doc.md", content_type="prose",
+            file_path="doc.md", chunk_count=0,
+        )
+        cat.update(
+            tumbler, bib_year=2020, bib_authors="X", bib_venue="V",
+            bib_citation_count=5, bib_semantic_scholar_id="ss1",
+            bib_openalex_id="W1", bib_doi="10.1/x",
+            bib_enriched_at="2026-01-01T00:00:00Z",
+        )
+        entry = cat.resolve(tumbler)
+        assert entry.bib_year == 2020
+        assert entry.bib_authors == "X"
+        assert entry.bib_venue == "V"
+        assert entry.bib_citation_count == 5
+        assert entry.bib_semantic_scholar_id == "ss1"
+        assert entry.bib_openalex_id == "W1"
+        assert entry.bib_doi == "10.1/x"
+        assert entry.bib_enriched_at == "2026-01-01T00:00:00Z"
+
+    def test_event_sourced_update_without_bib_kwargs_preserves_existing_bib(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Clobber regression for the ``update()`` emission site itself:
+        an update that doesn't pass bib_* must carry the current values
+        forward, not reset them (mirrors the non-event-sourced pin in
+        test_catalog_bib_columns.py)."""
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "doc.md", content_type="prose",
+            file_path="doc.md", chunk_count=0,
+        )
+        cat.update(tumbler, bib_year=2020, bib_authors="X")
+        cat.update(tumbler, chunk_count=9)
+        entry = cat.resolve(tumbler)
+        assert entry.chunk_count == 9
+        assert entry.bib_year == 2020
+        assert entry.bib_authors == "X"
+
 
 # ── delete_document ──────────────────────────────────────────────────────
 
@@ -357,6 +417,100 @@ class TestRenameCollectionEventSourced:
         ).fetchone()
         assert rows[0] == 2
 
+    def test_rename_preserves_enriched_bib_columns(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """nexus-6ha8a clobber regression: rename_collection's two
+        DocumentRegisteredPayload emission sites (per-row event-sourced
+        loop + shadow-emit loop) must carry forward the row's current
+        bib_* values, not reset them to defaults."""
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "a.md", content_type="prose",
+            file_path="a.md", physical_collection="docs__old",
+        )
+        cat.update(
+            tumbler, bib_year=2019, bib_authors="Dana", bib_venue="OSDI",
+            bib_citation_count=314, bib_semantic_scholar_id="ss42",
+        )
+
+        n = cat.rename_collection("docs__old", "docs__new")
+        assert n == 1
+
+        entry = cat.resolve(tumbler)
+        assert entry.physical_collection == "docs__new"
+        assert entry.bib_year == 2019
+        assert entry.bib_authors == "Dana"
+        assert entry.bib_venue == "OSDI"
+        assert entry.bib_citation_count == 314
+        assert entry.bib_semantic_scholar_id == "ss42"
+
+
+class TestUpdateDocumentCollectionEventSourced:
+    """nexus-6ha8a clobber regression: _update_document_collection_locked
+    (backing update_document_collection / update_documents_collection_batch)
+    is the fourth DocumentRegisteredPayload emission site — must carry
+    forward current bib_* values, not reset them."""
+
+    def test_update_document_collection_preserves_enriched_bib_columns(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "a.md", content_type="prose",
+            file_path="a.md", physical_collection="docs__old",
+        )
+        cat.update(
+            tumbler, bib_year=2019, bib_authors="Dana", bib_venue="OSDI",
+            bib_citation_count=314, bib_semantic_scholar_id="ss42",
+        )
+
+        assert cat.update_document_collection(str(tumbler), "docs__new") is True
+
+        entry = cat.resolve(tumbler)
+        assert entry.physical_collection == "docs__new"
+        assert entry.bib_year == 2019
+        assert entry.bib_authors == "Dana"
+        assert entry.bib_venue == "OSDI"
+        assert entry.bib_citation_count == 314
+        assert entry.bib_semantic_scholar_id == "ss42"
+
+    def test_update_documents_collection_batch_preserves_enriched_bib_columns(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "a.md", content_type="prose",
+            file_path="a.md", physical_collection="docs__old",
+        )
+        cat.update(
+            tumbler, bib_year=2019, bib_authors="Dana", bib_venue="OSDI",
+            bib_citation_count=314, bib_semantic_scholar_id="ss42",
+        )
+
+        n = cat.update_documents_collection_batch([(str(tumbler), "docs__new")])
+        assert n == 1
+
+        entry = cat.resolve(tumbler)
+        assert entry.physical_collection == "docs__new"
+        assert entry.bib_year == 2019
+        assert entry.bib_authors == "Dana"
+        assert entry.bib_venue == "OSDI"
+        assert entry.bib_citation_count == 314
+        assert entry.bib_semantic_scholar_id == "ss42"
+
 
 # ── End-to-end: full replay equals live SQLite ────────────────────────────
 
@@ -412,6 +566,49 @@ class TestFullReplayEqualsLive:
             ).fetchone()
         assert live_doc_a == proj_doc_a == (99,)
         assert live_doc_b == proj_doc_b == (str(a),)
+
+    def test_shadow_emit_rename_replay_reconstructs_bib_columns(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """nexus-6ha8a follow-up (cre-auto finding 4): rename_collection's
+        shadow-emit loop (ES=0 + shadow-emit on) writes events.jsonl for
+        future replay. Confirm the replayed JSONL actually reconstructs
+        the enriched bib_* values on the renamed row — not just that the
+        live SQLite happens to be correct."""
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "a.md", content_type="prose",
+            file_path="a.md", physical_collection="docs__old",
+        )
+        cat.update(
+            tumbler, bib_year=2019, bib_authors="Dana", bib_venue="OSDI",
+            bib_citation_count=314, bib_semantic_scholar_id="ss42",
+        )
+        n = cat.rename_collection("docs__old", "docs__new")
+        assert n == 1
+        cat._db.close()
+
+        # Replay events.jsonl into a fresh CatalogDB.
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        with sqlite3.connect(str(tmp_path / "projected.db")) as proj:
+            row = proj.execute(
+                "SELECT physical_collection, bib_year, bib_authors, "
+                "bib_venue, bib_citation_count, bib_semantic_scholar_id "
+                "FROM documents WHERE tumbler = ?",
+                (str(tumbler),),
+            ).fetchone()
+        assert row == ("docs__new", 2019, "Dana", "OSDI", 314, "ss42")
 
 
 # ── Shadow emit still suppressed ─────────────────────────────────────────

--- a/tests/test_catalog_knowledge_hook.py
+++ b/tests/test_catalog_knowledge_hook.py
@@ -311,6 +311,15 @@ class TestStorePutHook:
 
 
 class TestEnrichHook:
+    """nexus-9l2lg / nexus-6ha8a: bib_* persists under the ambient
+    default (event-sourced ON, RDR-101 Phase 3 PR ζ) as well as the
+    legacy non-event-sourced path — nexus-6ha8a extended the event-sourced
+    projector to carry bib_* forward across all 4
+    DocumentRegisteredPayload emission sites. No env pin needed here; see
+    test_catalog_bib_columns.py for the dedicated legacy-path (=0) parity
+    suite.
+    """
+
     def test_updates_catalog_metadata(self, tmp_path, monkeypatch):
         from nexus.commands.enrich import _catalog_enrich_hook
 
@@ -342,6 +351,127 @@ class TestEnrichHook:
 
         monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
         _catalog_enrich_hook(title="Test", bib_meta={})
+
+    def test_updates_catalog_bib_columns_s2_backend(self, tmp_path, monkeypatch):
+        from nexus.commands.enrich import _catalog_enrich_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("papers", "curator")
+        cat.register(owner, "S2 Paper", content_type="paper")
+
+        _catalog_enrich_hook(
+            title="S2 Paper",
+            bib_meta={
+                "authors": "Alice, Bob",
+                "year": 2024,
+                "venue": "SIGMOD",
+                "citation_count": 42,
+                "semantic_scholar_id": "ss123",
+            },
+            backend="s2",
+        )
+        entries = cat.find("S2 Paper")
+        assert len(entries) >= 1
+        entry = cat.resolve(entries[0].tumbler)
+        assert entry.bib_year == 2024
+        assert entry.bib_venue == "SIGMOD"
+        assert entry.bib_authors == "Alice, Bob"
+        assert entry.bib_citation_count == 42
+        assert entry.bib_semantic_scholar_id == "ss123"
+        assert entry.bib_enriched_at != ""
+
+    def test_updates_catalog_bib_columns_openalex_backend(self, tmp_path, monkeypatch):
+        from nexus.commands.enrich import _catalog_enrich_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("papers", "curator")
+        cat.register(owner, "OpenAlex Paper", content_type="paper")
+
+        _catalog_enrich_hook(
+            title="OpenAlex Paper",
+            bib_meta={
+                "authors": "Carol",
+                "year": 2023,
+                "venue": "ICML",
+                "citation_count": 7,
+                "openalex_id": "W999",
+                "doi": "10.1234/foo",
+            },
+            backend="openalex",
+        )
+        entries = cat.find("OpenAlex Paper")
+        assert len(entries) >= 1
+        entry = cat.resolve(entries[0].tumbler)
+        assert entry.bib_openalex_id == "W999"
+        assert entry.bib_doi == "10.1234/foo"
+        assert entry.bib_semantic_scholar_id == ""
+
+    def test_meta_no_longer_carries_venue_or_citation_count(
+        self, tmp_path, monkeypatch,
+    ):
+        from nexus.commands.enrich import _catalog_enrich_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("papers", "curator")
+        cat.register(owner, "S2 Meta Paper", content_type="paper")
+        cat.register(owner, "OA Meta Paper", content_type="paper")
+
+        _catalog_enrich_hook(
+            title="S2 Meta Paper",
+            bib_meta={
+                "authors": "A", "year": 2020, "venue": "V",
+                "citation_count": 1, "semantic_scholar_id": "ss1",
+            },
+            backend="s2",
+        )
+        _catalog_enrich_hook(
+            title="OA Meta Paper",
+            bib_meta={
+                "authors": "B", "year": 2021, "venue": "W",
+                "citation_count": 2, "openalex_id": "W1", "doi": "10.1/y",
+            },
+            backend="openalex",
+        )
+
+        s2_entry = cat.resolve(cat.find("S2 Meta Paper")[0].tumbler)
+        oa_entry = cat.resolve(cat.find("OA Meta Paper")[0].tumbler)
+        for entry in (s2_entry, oa_entry):
+            assert "venue" not in entry.meta
+            assert "citation_count" not in entry.meta
+            assert "bib_semantic_scholar_id" not in entry.meta
+            assert "bib_openalex_id" not in entry.meta
+            assert "bib_doi" not in entry.meta
+
+    def test_catalog_search_surfaces_bib_year_and_citation_count_after_enrich(
+        self, tmp_path, monkeypatch,
+    ):
+        from nexus.commands.enrich import _catalog_enrich_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("papers", "curator")
+        cat.register(owner, "Searchable Enriched Paper", content_type="paper")
+
+        _catalog_enrich_hook(
+            title="Searchable Enriched Paper",
+            bib_meta={
+                "authors": "Dana", "year": 2019, "venue": "OSDI",
+                "citation_count": 314, "semantic_scholar_id": "ss42",
+            },
+            backend="s2",
+        )
+
+        results = cat.find("Searchable Enriched Paper")
+        assert len(results) >= 1
+        assert results[0].bib_year == 2019
+        assert results[0].bib_citation_count == 314
 
 
 class TestEnrichHookSourcePathMatching:
@@ -410,7 +540,7 @@ class TestEnrichHookSourcePathMatching:
         assert entry_a is not None
         assert entry_a.year == 2020
         assert entry_a.author == "Author A"
-        assert entry_a.meta.get("bib_openalex_id") == "WAAA"
+        assert entry_a.bib_openalex_id == "WAAA"
         assert entry_a.meta.get("references") == ["WX", "WY"]
 
         # Paper B is untouched (was the bug: the LIMIT-1 fallback
@@ -419,7 +549,7 @@ class TestEnrichHookSourcePathMatching:
         assert entry_b is not None
         assert entry_b.year == 0
         assert entry_b.author == ""
-        assert entry_b.meta.get("bib_openalex_id", "") == ""
+        assert entry_b.bib_openalex_id == ""
 
     def test_source_paths_fan_out_across_multiple_rows(
         self, tmp_path, monkeypatch,
@@ -461,8 +591,8 @@ class TestEnrichHookSourcePathMatching:
 
         a = cat.by_file_path(owner, "papers/A.pdf")
         b = cat.by_file_path(owner, "papers/B.pdf")
-        assert a.year == 2021 and a.meta.get("bib_openalex_id") == "WBOTH"
-        assert b.year == 2021 and b.meta.get("bib_openalex_id") == "WBOTH"
+        assert a.year == 2021 and a.bib_openalex_id == "WBOTH"
+        assert b.year == 2021 and b.bib_openalex_id == "WBOTH"
 
     def test_no_source_paths_no_silent_clobber(self, tmp_path, monkeypatch):
         """Caller passes no source_paths and the title doesn't match
@@ -494,7 +624,7 @@ class TestEnrichHookSourcePathMatching:
 
         entry = cat.by_file_path(owner, "papers/X.pdf")
         assert entry.year == 0  # untouched
-        assert entry.meta.get("bib_openalex_id", "") == ""
+        assert entry.bib_openalex_id == ""
 
     def test_references_list_propagates_with_openalex(
         self, tmp_path, monkeypatch,

--- a/tests/test_catalog_mcp.py
+++ b/tests/test_catalog_mcp.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
 from nexus.mcp_server import (
     _reset_singletons,
     catalog_link,
@@ -187,6 +188,77 @@ def test_list_filters_by_content_type_with_pagination(cat) -> None:
     assert titles == ["rdr-A", "rdr-B"], (
         f"content_type filter not pushed into SQL: got {titles!r}"
     )
+
+
+_ENRICHED_BIB = {
+    "bib_year": 2019,
+    "bib_authors": "Dana",
+    "bib_venue": "OSDI",
+    "bib_citation_count": 314,
+    "bib_semantic_scholar_id": "ss42",
+}
+
+
+def test_list_owner_filtered_surfaces_bib_columns(cat) -> None:
+    """nexus-6ha8a follow-up (read-path split-brain, critic finding 1):
+    catalog_list(owner=...) routes through Catalog.by_owner(), which
+    truncated all 8 bib_* columns pre-fix."""
+    result = catalog_register(title="Enriched Paper", owner="1.1", content_type="paper")
+    cat.update(Tumbler.parse(result["tumbler"]), **_ENRICHED_BIB)
+
+    entries = catalog_list(owner="1.1")
+    assert len(entries) == 1
+    for key, value in _ENRICHED_BIB.items():
+        assert entries[0][key] == value, key
+
+
+def test_list_type_filtered_surfaces_bib_columns(cat) -> None:
+    """catalog_list(content_type=...) (no owner) routes through
+    Catalog.by_content_type()."""
+    result = catalog_register(title="Enriched Paper", owner="1.1", content_type="paper")
+    cat.update(Tumbler.parse(result["tumbler"]), **_ENRICHED_BIB)
+
+    entries = catalog_list(content_type="paper")
+    assert len(entries) == 1
+    for key, value in _ENRICHED_BIB.items():
+        assert entries[0][key] == value, key
+
+
+def test_list_unfiltered_surfaces_bib_columns(cat) -> None:
+    """catalog_list() with neither owner nor content_type routes
+    through Catalog.all_documents()."""
+    result = catalog_register(title="Enriched Paper", owner="1.1", content_type="paper")
+    cat.update(Tumbler.parse(result["tumbler"]), **_ENRICHED_BIB)
+
+    entries = catalog_list()
+    assert len(entries) == 1
+    for key, value in _ENRICHED_BIB.items():
+        assert entries[0][key] == value, key
+
+
+def test_search_filter_only_owner_surfaces_bib_columns(cat) -> None:
+    """catalog_search(owner=..., no query) is the filter-only SQL path
+    (no free-text FTS) — routes through Catalog.by_owner() same as
+    catalog_list."""
+    result = catalog_register(title="Enriched Paper", owner="1.1", content_type="paper")
+    cat.update(Tumbler.parse(result["tumbler"]), **_ENRICHED_BIB)
+
+    results = catalog_search(owner="1.1")
+    assert len(results) == 1
+    for key, value in _ENRICHED_BIB.items():
+        assert results[0][key] == value, key
+
+
+def test_search_filter_only_content_type_surfaces_bib_columns(cat) -> None:
+    """catalog_search(content_type=..., no query, no owner/corpus)
+    routes through Catalog.by_content_type()."""
+    result = catalog_register(title="Enriched Paper", owner="1.1", content_type="paper")
+    cat.update(Tumbler.parse(result["tumbler"]), **_ENRICHED_BIB)
+
+    results = catalog_search(content_type="paper")
+    assert len(results) == 1
+    for key, value in _ENRICHED_BIB.items():
+        assert results[0][key] == value, key
 
 
 def test_resolve_dashed_owner_returns_typed_error(cat) -> None:

--- a/tests/test_engine_version.py
+++ b/tests/test_engine_version.py
@@ -34,7 +34,11 @@ class TestRequiredEngineVersion:
         # indexed_at repair provenance (nexus-p5qk8); local installs receive
         # engine fixes ONLY via this floor/pin, so an advertised engine fix
         # moves the floor even with zero client-side hard dependency.
-        assert REQUIRED_ENGINE_VERSION == (0, 1, 42)
+        # ->(0,1,43) 2026-07-15: fix-delivery rule again — GH #1402
+        # (nexus-0gis0): grants-nexus-svc-1's bulk GRANT crash-looped boot on
+        # any install whose schema carries the superuser-owned diag view;
+        # v0.1.42 and earlier are broken upgrade targets for that class.
+        assert REQUIRED_ENGINE_VERSION == (0, 1, 43)
 
 
 class TestParseEngineVersion:
@@ -75,7 +79,8 @@ class TestFloorComparison:
         assert parse_engine_version("0.1.5") < REQUIRED_ENGINE_VERSION
 
     def test_at_floor_compares_equal(self) -> None:
-        assert parse_engine_version("0.1.42") == REQUIRED_ENGINE_VERSION
+        floor_str = ".".join(str(p) for p in REQUIRED_ENGINE_VERSION)
+        assert parse_engine_version(floor_str) == REQUIRED_ENGINE_VERSION
 
     def test_above_floor_compares_greater(self) -> None:
         assert parse_engine_version("0.2.0") > REQUIRED_ENGINE_VERSION

--- a/tests/test_enrich_command.py
+++ b/tests/test_enrich_command.py
@@ -2,12 +2,17 @@
 """Tests for nx enrich CLI command."""
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
 from nexus.commands.enrich import enrich
 from nexus.db.http_vector_client import HttpVectorClient
+from nexus.db.t3 import T3Database
 
 
 @patch("nexus.db.make_t3")
@@ -397,3 +402,218 @@ def test_enrich_source_auto_uses_s2_when_key_present(
     assert "Backend: s2" in result.output
     mock_oa.assert_not_called()
     mock_s2.assert_called_once_with("Paper S2")
+
+
+# ── nexus-9l2lg: --backfill-catalog ─────────────────────────────────────────
+
+
+def _make_catalog(tmp_path: Path) -> tuple[Path, Catalog]:
+    catalog_dir = tmp_path / "catalog"
+    cat = Catalog.init(catalog_dir)
+    return catalog_dir, cat
+
+
+@pytest.fixture(autouse=True)
+def _backfill_catalog_env(monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+
+class TestBackfillCatalog:
+    """nexus-9l2lg Task 4: ``nx enrich bib COLLECTION --backfill-catalog``
+    re-derives the catalog bib_* write from already-enriched T3 chunk
+    metadata, with zero external API calls. Uses a real T3 (EphemeralClient)
+    + real local Catalog rather than mocks (repo convention: integration
+    over mocks for boundary-spanning behavior).
+
+    No env pin needed: nexus-6ha8a extended the event-sourced projector
+    to persist bib_* too, so these assertions hold under the ambient
+    default (ON, RDR-101 Phase 3 PR ζ). See test_catalog_bib_columns.py
+    for the dedicated legacy-path (=0) parity suite.
+    """
+
+    def _seed_collection_and_catalog(
+        self, tmp_path: Path, monkeypatch, local_t3: T3Database,
+        collection: str = "knowledge__nexus-1-1__voyage-context-3__v1",
+    ) -> tuple[Catalog, str, Tumbler]:
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        monkeypatch.setattr("nexus.db.make_t3", lambda: local_t3)
+
+        col = local_t3.get_or_create_collection(collection)
+        col.add(
+            ids=["c1", "c2"],
+            documents=["chunk one text", "chunk two text"],
+            metadatas=[
+                {
+                    "title": "Enriched Paper", "source_path": "/papers/e.pdf",
+                    "bib_year": 2019, "bib_venue": "OSDI",
+                    "bib_authors": "Dana", "bib_citation_count": 314,
+                    "bib_semantic_scholar_id": "ss42",
+                },
+                {
+                    "title": "Enriched Paper", "source_path": "/papers/e.pdf",
+                    "bib_year": 2019, "bib_venue": "OSDI",
+                    "bib_authors": "Dana", "bib_citation_count": 314,
+                    "bib_semantic_scholar_id": "ss42",
+                },
+            ],
+        )
+
+        owner = cat.register_owner("papers", "curator")
+        cat.register(
+            owner, "Enriched Paper", content_type="paper",
+            physical_collection=collection, file_path="papers/e.pdf",
+        )
+        return cat, collection, owner
+
+    def test_backfill_catalog_populates_bib_columns_from_enriched_chunks(
+        self, tmp_path: Path, monkeypatch, local_t3: T3Database,
+    ) -> None:
+        cat, collection, _owner = self._seed_collection_and_catalog(
+            tmp_path, monkeypatch, local_t3,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["bib", collection, "--backfill-catalog"])
+        assert result.exit_code == 0, result.output
+        assert "Backfilled 1 titles" in result.output
+
+        results = cat.find("Enriched Paper")
+        assert len(results) == 1
+        found = cat.resolve(results[0].tumbler)
+        assert found.bib_year == 2019
+        assert found.bib_venue == "OSDI"
+        assert found.bib_authors == "Dana"
+        assert found.bib_citation_count == 314
+        assert found.bib_semantic_scholar_id == "ss42"
+
+    def test_backfill_catalog_idempotent_second_run(
+        self, tmp_path: Path, monkeypatch, local_t3: T3Database,
+    ) -> None:
+        cat, collection, _owner = self._seed_collection_and_catalog(
+            tmp_path, monkeypatch, local_t3,
+        )
+
+        runner = CliRunner()
+        first = runner.invoke(enrich, ["bib", collection, "--backfill-catalog"])
+        assert first.exit_code == 0, first.output
+        before = cat.resolve(cat.find("Enriched Paper")[0].tumbler)
+
+        second = runner.invoke(enrich, ["bib", collection, "--backfill-catalog"])
+        assert second.exit_code == 0, second.output
+        assert "Backfilled 1 titles" in second.output
+
+        after = cat.resolve(cat.find("Enriched Paper")[0].tumbler)
+        for key in (
+            "bib_year", "bib_venue", "bib_authors", "bib_citation_count",
+            "bib_semantic_scholar_id",
+        ):
+            assert getattr(before, key) == getattr(after, key), key
+
+    def test_backfill_catalog_skips_non_enriched_chunks(
+        self, tmp_path: Path, monkeypatch, local_t3: T3Database,
+    ) -> None:
+        cat, collection, owner = self._seed_collection_and_catalog(
+            tmp_path, monkeypatch, local_t3,
+        )
+        col = local_t3.get_or_create_collection(collection)
+        col.add(
+            ids=["c3"],
+            documents=["chunk three text, not enriched"],
+            metadatas=[{
+                "title": "Non-Enriched Paper", "source_path": "/papers/n.pdf",
+            }],
+        )
+        cat.register(
+            owner, "Non-Enriched Paper", content_type="paper",
+            physical_collection=collection, file_path="papers/n.pdf",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["bib", collection, "--backfill-catalog"])
+        assert result.exit_code == 0, result.output
+        assert "Backfilled 1 titles" in result.output
+
+        enriched = cat.resolve(cat.find("Enriched Paper")[0].tumbler)
+        assert enriched.bib_year == 2019
+
+        non_enriched = cat.resolve(cat.find("Non-Enriched Paper")[0].tumbler)
+        assert non_enriched.bib_year == 0
+        assert non_enriched.bib_semantic_scholar_id == ""
+
+    def test_backfill_catalog_counts_skipped_no_row_separately(
+        self, tmp_path: Path, monkeypatch, local_t3: T3Database,
+    ) -> None:
+        """nexus-6ha8a follow-up (critic finding 3): _backfill_catalog_
+        from_chunks previously incremented titles_backfilled
+        unconditionally, even when _catalog_enrich_hook silently
+        no-oped (no matching catalog row). A title with enriched
+        chunks but NO catalog row must count as skipped, not
+        backfilled."""
+        # Distinct collection name: chromadb's EphemeralClient has known
+        # process-shared-state behavior across tests reusing the same
+        # collection name (see project_chromadb_ephemeral_shared_state
+        # memory) — sibling TestBackfillCatalog tests add their own
+        # chunks (e.g. "c3") to the default name, which would silently
+        # inflate this test's exact chunks_scanned assertion if reused.
+        cat, collection, owner = self._seed_collection_and_catalog(
+            tmp_path, monkeypatch, local_t3,
+            collection="knowledge__nexus-1-1__voyage-context-3__v2",
+        )
+        # A second enriched title with chunks but NO matching catalog
+        # row anywhere (no register() call for it) — the hook's
+        # source_path / title / FTS lookups must all miss.
+        col = local_t3.get_or_create_collection(collection)
+        col.add(
+            ids=["c9"],
+            documents=["orphan enriched chunk text"],
+            metadatas=[{
+                "title": "Orphan Enriched Paper", "source_path": "/papers/orphan.pdf",
+                "bib_year": 2021, "bib_venue": "SOSP",
+                "bib_authors": "Eve", "bib_citation_count": 7,
+                "bib_semantic_scholar_id": "ss-orphan",
+            }],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["bib", collection, "--backfill-catalog"])
+        assert result.exit_code == 0, result.output
+        # 2 enriched titles total ("Enriched Paper" has a matching row;
+        # "Orphan Enriched Paper" does not) -> N-1 backfilled, 1 skipped.
+        assert "Backfilled 1 titles" in result.output
+        assert "1 titles skipped (no matching catalog row)" in result.output
+
+        from nexus.commands.enrich import _backfill_catalog_from_chunks
+        # Direct call (fresh collection state unchanged by the CLI run
+        # above, since the CLI already applied the update) confirms the
+        # exact return-tuple contract idempotently: "Enriched Paper" is
+        # still matched (re-applies the same values -> still counted as
+        # backfilled), "Orphan Enriched Paper" is still unmatched.
+        titles_backfilled, chunks_scanned, titles_skipped_no_row = (
+            _backfill_catalog_from_chunks(collection)
+        )
+        assert titles_backfilled == 1
+        assert titles_skipped_no_row == 1
+        assert chunks_scanned == 3  # c1, c2 (Enriched Paper) + c9 (orphan)
+
+    def test_backfill_catalog_makes_zero_external_calls(
+        self, tmp_path: Path, monkeypatch, local_t3: T3Database,
+    ) -> None:
+        self._seed_collection_and_catalog(tmp_path, monkeypatch, local_t3)
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("external bib_enricher call must not happen")
+
+        monkeypatch.setattr("nexus.bib_enricher.enrich", _boom, raising=False)
+        monkeypatch.setattr(
+            "nexus.bib_enricher_openalex.enrich", _boom, raising=False,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["bib", "knowledge__nexus-1-1__voyage-context-3__v1", "--backfill-catalog"],
+        )
+        assert result.exit_code == 0, result.output

--- a/tests/test_enrich_command.py
+++ b/tests/test_enrich_command.py
@@ -561,7 +561,7 @@ class TestBackfillCatalog:
         # inflate this test's exact chunks_scanned assertion if reused.
         cat, collection, owner = self._seed_collection_and_catalog(
             tmp_path, monkeypatch, local_t3,
-            collection="knowledge__nexus-1-1__voyage-context-3__v2",
+            collection="knowledge__nexus-1-1__bge-base-en-v15-768__v2",
         )
         # A second enriched title with chunks but NO matching catalog
         # row anywhere (no register() call for it) — the hook's
@@ -602,7 +602,14 @@ class TestBackfillCatalog:
     def test_backfill_catalog_makes_zero_external_calls(
         self, tmp_path: Path, monkeypatch, local_t3: T3Database,
     ) -> None:
-        self._seed_collection_and_catalog(tmp_path, monkeypatch, local_t3)
+        # Non-voyage collection name: this is a local-mode test (the
+        # embedder segment is incidental), and the RDR-109 mode lint
+        # flags any test whose source mentions voyage-(context|code)-3
+        # without the cloud_mode fixture.
+        self._seed_collection_and_catalog(
+            tmp_path, monkeypatch, local_t3,
+            collection="knowledge__nexus-1-1__bge-base-en-v15-768__v1",
+        )
 
         def _boom(*args, **kwargs):
             raise AssertionError("external bib_enricher call must not happen")
@@ -614,6 +621,6 @@ class TestBackfillCatalog:
 
         runner = CliRunner()
         result = runner.invoke(
-            enrich, ["bib", "knowledge__nexus-1-1__voyage-context-3__v1", "--backfill-catalog"],
+            enrich, ["bib", "knowledge__nexus-1-1__bge-base-en-v15-768__v1", "--backfill-catalog"],
         )
         assert result.exit_code == 0, result.output

--- a/tests/test_taxonomy_rebuild_link_cleanup.py
+++ b/tests/test_taxonomy_rebuild_link_cleanup.py
@@ -1,0 +1,168 @@
+"""persist_rebuild_topics must delete topic_links touching replaced topics.
+
+nexus-y17x9: the rebuild persist half cleared topic_assignments + topics for
+the target collection but left topic_links rows referencing the deleted topic
+ids dangling. On the PG/HttpTaxonomyStore side ``topic_links.from/to_topic_id``
+carry ``ON DELETE CASCADE``, so links self-clean there — SQLite runs with
+foreign_keys OFF, so the missing explicit DELETE silently orphaned links
+(~6.9k orphaned rows observed in the live pre-migration store, 2026-07-14
+audit). This suite pins the SQLite leg to PG's cascade semantics.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.db.t2 import T2Database
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> T2Database:
+    with T2Database(tmp_path / "t2.db") as database:
+        yield database
+
+
+def _seed_topic(db: T2Database, label: str, collection: str) -> int:
+    cur = db.taxonomy.conn.execute(
+        "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+        (label, collection, 1, "2026-07-14T00:00:00Z"),
+    )
+    db.taxonomy.conn.commit()
+    return cur.lastrowid
+
+
+def _link_count(db: T2Database) -> int:
+    return db.taxonomy.conn.execute("SELECT COUNT(*) FROM topic_links").fetchone()[0]
+
+
+def _orphan_link_count(db: T2Database) -> int:
+    return db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topic_links l "
+        "LEFT JOIN topics f ON l.from_topic_id = f.id "
+        "LEFT JOIN topics t ON l.to_topic_id = t.id "
+        "WHERE f.id IS NULL OR t.id IS NULL"
+    ).fetchone()[0]
+
+
+class TestRebuildLinkCleanup:
+    def test_rebuild_deletes_links_touching_replaced_topics(self, db: T2Database) -> None:
+        a = _seed_topic(db, "topic-a", "code__x")
+        b = _seed_topic(db, "topic-b", "code__x")
+        db.taxonomy.upsert_topic_links(
+            [{"from_topic_id": a, "to_topic_id": b, "link_count": 2, "link_types": ["cites"]}]
+        )
+        assert _link_count(db) == 1
+
+        db.taxonomy.persist_rebuild_topics("code__x", {"specs": [], "manual_transfers": {}})
+
+        assert _link_count(db) == 0
+        assert _orphan_link_count(db) == 0
+
+    def test_rebuild_deletes_cross_collection_links_but_keeps_other_topics(
+        self, db: T2Database,
+    ) -> None:
+        a = _seed_topic(db, "topic-a", "code__x")
+        outside = _seed_topic(db, "topic-outside", "docs__y")
+        db.taxonomy.upsert_topic_links(
+            [
+                {"from_topic_id": a, "to_topic_id": outside, "link_count": 1, "link_types": ["relates"]},
+                {"from_topic_id": outside, "to_topic_id": a, "link_count": 1, "link_types": ["relates"]},
+            ]
+        )
+        assert _link_count(db) == 2
+
+        db.taxonomy.persist_rebuild_topics("code__x", {"specs": [], "manual_transfers": {}})
+
+        assert _link_count(db) == 0
+        assert _orphan_link_count(db) == 0
+        survivors = db.taxonomy.conn.execute(
+            "SELECT id FROM topics WHERE collection = ?", ("docs__y",),
+        ).fetchall()
+        assert [row[0] for row in survivors] == [outside]
+
+    def test_delete_topic_removes_links_both_directions(self, db: T2Database) -> None:
+        a = _seed_topic(db, "topic-a", "code__x")
+        b = _seed_topic(db, "topic-b", "code__x")
+        c = _seed_topic(db, "topic-c", "code__x")
+        db.taxonomy.upsert_topic_links(
+            [
+                {"from_topic_id": a, "to_topic_id": b, "link_count": 1, "link_types": ["cites"]},
+                {"from_topic_id": c, "to_topic_id": a, "link_count": 1, "link_types": ["cites"]},
+                {"from_topic_id": b, "to_topic_id": c, "link_count": 1, "link_types": ["cites"]},
+            ]
+        )
+
+        db.taxonomy.delete_topic(a)
+
+        rows = db.taxonomy.conn.execute(
+            "SELECT from_topic_id, to_topic_id FROM topic_links"
+        ).fetchall()
+        assert rows == [(b, c)]
+        assert _orphan_link_count(db) == 0
+
+    def test_merge_topics_removes_source_links_keeps_target_links(self, db: T2Database) -> None:
+        src = _seed_topic(db, "topic-src", "code__x")
+        tgt = _seed_topic(db, "topic-tgt", "code__x")
+        other = _seed_topic(db, "topic-other", "code__x")
+        db.taxonomy.upsert_topic_links(
+            [
+                {"from_topic_id": src, "to_topic_id": other, "link_count": 1, "link_types": ["cites"]},
+                {"from_topic_id": other, "to_topic_id": src, "link_count": 1, "link_types": ["cites"]},
+                {"from_topic_id": tgt, "to_topic_id": other, "link_count": 2, "link_types": ["relates"]},
+            ]
+        )
+
+        db.taxonomy.merge_topics(src, tgt)
+
+        rows = db.taxonomy.conn.execute(
+            "SELECT from_topic_id, to_topic_id FROM topic_links"
+        ).fetchall()
+        assert rows == [(tgt, other)]
+        assert _orphan_link_count(db) == 0
+
+    def test_purge_assignments_for_doc_removes_links_of_emptied_topics(
+        self, db: T2Database,
+    ) -> None:
+        a = _seed_topic(db, "topic-a", "proj")
+        b = _seed_topic(db, "topic-b", "proj")
+        for doc_id, topic_id in [("note1", a), ("note2", b)]:
+            db.taxonomy.conn.execute(
+                "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
+                (doc_id, topic_id),
+            )
+        db.taxonomy.conn.commit()
+        db.taxonomy.upsert_topic_links(
+            [{"from_topic_id": a, "to_topic_id": b, "link_count": 1, "link_types": ["relates"]}]
+        )
+
+        removed = db.taxonomy.purge_assignments_for_doc("proj", "note1")
+
+        assert removed == 1
+        remaining = db.taxonomy.conn.execute(
+            "SELECT id FROM topics ORDER BY id"
+        ).fetchall()
+        assert [row[0] for row in remaining] == [b]
+        assert _link_count(db) == 0
+        assert _orphan_link_count(db) == 0
+
+    def test_rebuild_keeps_links_between_untouched_collections(self, db: T2Database) -> None:
+        a = _seed_topic(db, "topic-a", "code__x")
+        y1 = _seed_topic(db, "topic-y1", "docs__y")
+        y2 = _seed_topic(db, "topic-y2", "docs__y")
+        db.taxonomy.upsert_topic_links(
+            [
+                {"from_topic_id": a, "to_topic_id": y1, "link_count": 1, "link_types": ["relates"]},
+                {"from_topic_id": y1, "to_topic_id": y2, "link_count": 3, "link_types": ["cites"]},
+            ]
+        )
+        assert _link_count(db) == 2
+
+        db.taxonomy.persist_rebuild_topics("code__x", {"specs": [], "manual_transfers": {}})
+
+        rows = db.taxonomy.conn.execute(
+            "SELECT from_topic_id, to_topic_id FROM topic_links"
+        ).fetchall()
+        assert rows == [(y1, y2)]
+        assert _orphan_link_count(db) == 0

--- a/tests/test_taxonomy_review_auto.py
+++ b/tests/test_taxonomy_review_auto.py
@@ -1,0 +1,958 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit + CLI tests for nx taxonomy review --auto (nexus-6i01g, nexus-vfs67).
+
+Design: nx memory get -p nexus -t design-taxonomy-review-auto.md (approved).
+Reference rubric/results: nx memory get -p nexus -t taxonomy-auto-review-2026-07-14.
+
+Two suites:
+
+* ``TestReviewVerdictsDispatch`` — pure-function tests for
+  ``_generate_review_verdicts_batch`` / ``_REVIEW_VERDICT_SCHEMA``, modeled
+  directly on ``tests/test_rdr_085_glossary_labeler.py``'s
+  ``patch("nexus.operators.dispatch.claude_dispatch", ...)`` pattern (the
+  import is deferred-at-call-time inside the dispatcher, so patching must
+  target that module path, not ``nexus.commands.taxonomy_cmd``).
+* ``TestReviewAutoCLI`` — CLI-level tests (cases a-p from the bead task
+  list, plus the stacked-review follow-up findings), modeled on
+  ``tests/test_taxonomy.py::TestReviewCLI``'s ``_seed_topics`` /
+  ``_t2_router`` / ``patch("nexus.commands.taxonomy_cmd._default_db_path", ...)``
+  + ``patch.object(_mi, "t2_index_write", ...)`` conventions.
+
+Verdicts are keyed by the REAL topic id (schema property ``"id"``), not a
+positional ``idx`` — the review-gate fix for the wrong-topic-verdict class
+(nexus-6i01g stacked-review finding 3).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import nexus.mcp_infra as _mi
+from nexus.commands.taxonomy_cmd import taxonomy
+from nexus.db.t2 import T2Database
+
+# ── Shared seeding + mocking helpers ────────────────────────────────────────
+
+
+def _seed_topic(
+    db_path: Path,
+    label: str,
+    *,
+    collection: str = "proj",
+    doc_count: int = 1,
+    terms: list[str] | None = None,
+    review_status: str = "pending",
+    n_docs: int | None = None,
+) -> int:
+    """Insert one topic (+ topic_assignments) and return its id."""
+    import json as _json
+
+    with T2Database(db_path) as db:
+        db.taxonomy.conn.execute(
+            "INSERT INTO topics "
+            "(label, collection, doc_count, created_at, review_status, terms) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                label,
+                collection,
+                doc_count,
+                "2026-01-01T00:00:00Z",
+                review_status,
+                _json.dumps(terms or ["term-a", "term-b"]),
+            ),
+        )
+        topic_id = db.taxonomy.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        n = n_docs if n_docs is not None else doc_count
+        for i in range(n):
+            db.taxonomy.conn.execute(
+                "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
+                (f"{label}-doc-{i}.py", topic_id),
+            )
+        db.taxonomy.conn.commit()
+    return topic_id
+
+
+def _t2_router(db_path: Path):
+    """Return a t2_index_write stub that routes through db_path (RDR-151 P3)."""
+    def _router(fn):
+        with T2Database(db_path) as db:
+            return fn(db)
+    return _router
+
+
+def _t2_router_delete_fails_for(db_path: Path, failing_id: int):
+    """Like ``_t2_router`` but ``delete_topic(failing_id)`` raises.
+
+    Used to test apply-loop resilience (stacked-review finding 2): one bad
+    delete must not abort the remaining deletes/merges in the batch. Only
+    ``delete_topic`` is monkeypatched; ``rename_topic``/``mark_topic_reviewed``/
+    ``merge_topics`` are untouched.
+    """
+    def _router(fn):
+        with T2Database(db_path) as db:
+            orig_delete = db.taxonomy.delete_topic
+
+            def _delete(topic_id, **kw):
+                if topic_id == failing_id:
+                    raise RuntimeError("boom-delete")
+                return orig_delete(topic_id, **kw)
+
+            db.taxonomy.delete_topic = _delete
+            return fn(db)
+    return _router
+
+
+def _dispatch_by_topic_id(verdicts_by_id: dict[int, dict]):
+    """Build a fake ``claude_dispatch`` keyed by REAL topic id.
+
+    ``_generate_review_verdicts_batch`` embeds ``id=<topic_id>`` per prompt
+    line; this parses those back out so tests can specify verdicts by real
+    topic id and the fake naturally scopes its response to whichever ids
+    are actually in the current batch's prompt (needed for multi-batch
+    tests). Topics with no entry in ``verdicts_by_id`` are omitted from the
+    response (fail-open: they land as None / stay pending).
+    """
+    async def _fake(prompt: str, schema: dict, **kw):  # noqa: ARG001
+        ids_in_prompt = {int(m) for m in re.findall(r"id=(\d+)", prompt)}
+        out = [
+            {"id": tid, **v}
+            for tid, v in verdicts_by_id.items()
+            if tid in ids_in_prompt
+        ]
+        return {"verdicts": out}
+
+    return _fake
+
+
+# ── _generate_review_verdicts_batch / _REVIEW_VERDICT_SCHEMA ───────────────
+
+
+class TestReviewVerdictsDispatch:
+
+    @pytest.mark.asyncio
+    async def test_accept_verdict_parses(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old label", ["a", "b"], ["doc1.py"], "proj")]
+        dispatched = AsyncMock(return_value={"verdicts": [{"id": 101, "action": "accept"}]})
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [{"action": "accept"}]
+
+    @pytest.mark.asyncio
+    async def test_rename_with_valid_label(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(
+            return_value={"verdicts": [{"id": 101, "action": "rename", "label": "New Label"}]}
+        )
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [{"action": "rename", "label": "New Label"}]
+
+    @pytest.mark.asyncio
+    async def test_rename_with_invalid_label_length_becomes_none(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(
+            return_value={"verdicts": [{"id": 101, "action": "rename", "label": "x"}]}
+        )
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [None]
+
+    @pytest.mark.asyncio
+    async def test_rename_label_stripped_before_length_check(self) -> None:
+        """Finding 5: strip happens BEFORE the length check, not after.
+
+        "  x  " strips to "x" (len 1) — must be rejected, not accepted on
+        the strength of its padded length.
+        """
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(
+            return_value={"verdicts": [{"id": 101, "action": "rename", "label": "  x  "}]}
+        )
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [None]
+
+    @pytest.mark.asyncio
+    async def test_rename_label_over_60_chars_rejected(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(
+            return_value={"verdicts": [{"id": 101, "action": "rename", "label": "Z" * 61}]}
+        )
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [None]
+
+    @pytest.mark.asyncio
+    async def test_rename_label_stored_stripped_when_valid(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(
+            return_value={
+                "verdicts": [{"id": 101, "action": "rename", "label": "  Good Label  "}],
+            }
+        )
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [{"action": "rename", "label": "Good Label"}]
+
+    @pytest.mark.asyncio
+    async def test_merge_with_target_id(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(
+            return_value={
+                "verdicts": [{"id": 101, "action": "merge", "target_id": 202, "reason": "dup"}],
+            }
+        )
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [{"action": "merge", "target_id": 202, "reason": "dup"}]
+
+    @pytest.mark.asyncio
+    async def test_merge_without_target_id_becomes_none(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(return_value={"verdicts": [{"id": 101, "action": "merge"}]})
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [None]
+
+    @pytest.mark.asyncio
+    async def test_delete_with_reason(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(
+            return_value={"verdicts": [{"id": 101, "action": "delete", "reason": "pollution"}]}
+        )
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [{"action": "delete", "reason": "pollution"}]
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_ignored(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(return_value={"verdicts": [{"id": 101, "action": "explode"}]})
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [None]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_raises_returns_all_none(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj"), (102, "b", [], [], "proj")]
+        with patch(
+            "nexus.operators.dispatch.claude_dispatch",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [None, None]
+
+    @pytest.mark.asyncio
+    async def test_missing_verdicts_key_returns_all_none(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(return_value={"nope": []})
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [None]
+
+    @pytest.mark.asyncio
+    async def test_id_not_in_batch_ignored(self) -> None:
+        """Finding 3: an entry keyed with an id NOT present in this batch's
+
+        items is ignored entirely (not misapplied to some other slot by
+        position) — the wrong-topic-verdict class this fix eliminates.
+        """
+        from nexus.commands import taxonomy_cmd
+
+        items = [(101, "old", [], [], "proj")]
+        dispatched = AsyncMock(return_value={"verdicts": [{"id": 9999, "action": "accept"}]})
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch(items)
+        assert results == [None]
+
+    @pytest.mark.asyncio
+    async def test_empty_items_returns_empty_without_dispatch(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        dispatched = AsyncMock()
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_review_verdicts_batch([])
+        assert results == []
+        assert not dispatched.called
+
+    @pytest.mark.asyncio
+    async def test_prompt_keys_by_id_not_position_and_merge_wording(self) -> None:
+        """Finding 3 + 4: the prompt must not present a separate ordinal
+
+        index alongside the id (the dual-numbering ambiguity this fix
+        eliminates), and the merge instruction must allow same-collection
+        targets not necessarily listed in this batch.
+        """
+        from nexus.commands import taxonomy_cmd
+
+        captured: dict[str, str] = {}
+
+        async def fake_dispatch(prompt: str, schema: dict, **kw):
+            captured["prompt"] = prompt
+            return {"verdicts": []}
+
+        items = [(101, "old", ["term"], ["doc.py"], "proj")]
+        with patch("nexus.operators.dispatch.claude_dispatch", fake_dispatch):
+            await taxonomy_cmd._generate_review_verdicts_batch(items)
+
+        prompt = captured["prompt"]
+        assert "id=101" in prompt
+        assert "same collection" in prompt
+        assert "id= value" in prompt
+        # No positional idx concept anywhere in the instructions.
+        assert "idx" not in prompt.lower()
+
+
+# ── CLI: nx taxonomy review --auto ──────────────────────────────────────────
+
+
+class TestReviewAutoCLI:
+
+    def test_accept_applies_immediately_no_confirm(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        tid = _seed_topic(db_path, "old label", doc_count=3)
+        dispatch = AsyncMock(side_effect=_dispatch_by_topic_id({tid: {"action": "accept"}}))
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(taxonomy, ["review", "--auto", "--collection", "proj"])
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            status = db.taxonomy.get_topic_by_id(tid)["review_status"]
+        assert status == "accepted"
+
+    def test_rename_applies_immediately(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        tid = _seed_topic(db_path, "bad label", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {tid: {"action": "rename", "label": "Deep Learning"}}
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(taxonomy, ["review", "--auto", "--collection", "proj"])
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            topic = db.taxonomy.get_topic_by_id(tid)
+        assert topic["label"] == "Deep Learning"
+        assert topic["review_status"] == "accepted"
+
+    def test_delete_declined_by_default_leaves_pending(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        tid = _seed_topic(db_path, "junk", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {tid: {"action": "delete", "reason": "pollution"}}
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj"], input="n\n",
+            )
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            count = db.taxonomy.conn.execute("SELECT COUNT(*) FROM topics").fetchone()[0]
+            status = db.taxonomy.get_topic_by_id(tid)["review_status"]
+        assert count == 1
+        assert status == "pending"
+        # Finding 6: declined destructive items count toward the skipped
+        # bucket in the summary line, not silently dropped from the tally.
+        assert "0 accepted, 0 renamed, 0 deleted, 0 merged, 1 skipped, 0 failed." in result.output
+
+    def test_delete_applied_with_yes(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        tid = _seed_topic(db_path, "junk", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {tid: {"action": "delete", "reason": "pollution"}}
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj", "--yes"],
+            )
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            count = db.taxonomy.conn.execute("SELECT COUNT(*) FROM topics").fetchone()[0]
+        assert count == 0
+
+    def test_merge_applied_with_confirm(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        source_id = _seed_topic(db_path, "source", doc_count=2, n_docs=2)
+        target_id = _seed_topic(
+            db_path, "target", doc_count=3, n_docs=3, review_status="accepted",
+        )
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {source_id: {"action": "merge", "target_id": target_id, "reason": "dup"}}
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj"], input="y\n",
+            )
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            assert db.taxonomy.get_topic_by_id(source_id) is None
+            target = db.taxonomy.get_topic_by_id(target_id)
+        assert target["doc_count"] == 5
+
+    def test_merge_nonexistent_target_stays_pending(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        source_id = _seed_topic(db_path, "source", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {source_id: {"action": "merge", "target_id": 999999, "reason": "dup"}}
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(taxonomy, ["review", "--auto", "--collection", "proj"])
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            count = db.taxonomy.conn.execute("SELECT COUNT(*) FROM topics").fetchone()[0]
+            status = db.taxonomy.get_topic_by_id(source_id)["review_status"]
+        assert count == 1
+        assert status == "pending"
+
+    def test_merge_cross_collection_target_stays_pending(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        source_id = _seed_topic(db_path, "source", collection="proj", doc_count=1)
+        target_id = _seed_topic(db_path, "target", collection="other", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {source_id: {"action": "merge", "target_id": target_id, "reason": "dup"}}
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(taxonomy, ["review", "--auto", "--collection", "proj"])
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            status = db.taxonomy.get_topic_by_id(source_id)["review_status"]
+        assert status == "pending"
+
+    def test_merge_self_target_stays_pending_and_not_in_plan(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        source_id = _seed_topic(db_path, "source", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {source_id: {"action": "merge", "target_id": source_id, "reason": "dup"}}
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(taxonomy, ["review", "--auto", "--collection", "proj"])
+
+        assert result.exit_code == 0, result.output
+        assert "Destructive" not in result.output
+        with T2Database(db_path) as db:
+            status = db.taxonomy.get_topic_by_id(source_id)["review_status"]
+        assert status == "pending"
+
+    def test_merge_target_also_deleted_merge_pending_delete_applies(
+        self, tmp_path: Path,
+    ) -> None:
+        db_path = tmp_path / "memory.db"
+        a_id = _seed_topic(db_path, "topic-a", doc_count=1)
+        b_id = _seed_topic(db_path, "topic-b", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {
+                    a_id: {"action": "merge", "target_id": b_id, "reason": "dup"},
+                    b_id: {"action": "delete", "reason": "pollution"},
+                }
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj"], input="y\n",
+            )
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            a_status = db.taxonomy.get_topic_by_id(a_id)["review_status"]
+            b_topic = db.taxonomy.get_topic_by_id(b_id)
+        assert a_status == "pending"
+        assert b_topic is None
+
+    def test_merge_chain_validation_drops_target_that_is_also_a_source(
+        self, tmp_path: Path,
+    ) -> None:
+        """Finding 1 (unit-level, dry-run): A->B, B->C in the same batch.
+
+        The second-pass guard must drop A->B (B is itself a merge SOURCE
+        this run) while leaving B->C valid — proven here purely at the
+        validation layer via --dry-run so no apply-time mechanics are in
+        play. Isolates the merge_source_ids guard from the
+        data-integrity/apply-order concern covered by the sibling
+        --yes test below.
+        """
+        db_path = tmp_path / "memory.db"
+        a_id = _seed_topic(db_path, "topic-a", doc_count=1)
+        b_id = _seed_topic(db_path, "topic-b", doc_count=1)
+        c_id = _seed_topic(db_path, "topic-c", doc_count=1, review_status="accepted")
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {
+                    a_id: {"action": "merge", "target_id": b_id, "reason": "dup"},
+                    b_id: {"action": "merge", "target_id": c_id, "reason": "dup"},
+                }
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj", "--dry-run"],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Only the B->C merge appears in the destructive plan; A->B was
+        # dropped at validation (B is a merge source in this run).
+        assert "topic-b" in result.output and "topic-c" in result.output
+        assert "topic-a" not in result.output.split("Destructive actions pending:")[-1]
+        assert (
+            "0 would be accepted, 0 would be renamed, 0 would be deleted, "
+            "1 would be merged, 1 skipped."
+            in result.output
+        )
+
+    def test_merge_chain_same_run_applies_b_to_c_drops_a_to_b_data_intact(
+        self, tmp_path: Path,
+    ) -> None:
+        """Finding 1 (CRITICAL, reproduction): A->B (target), B->C (source)
+
+        in the same run. merge_topics has no target-existence check and T2
+        SQLite runs with foreign keys off, so without the merge-source
+        guard, applying A->B after B->C deletes B would silently orphan
+        A's assignments. Proves: B->C applies (deterministic regardless of
+        candidate order), A->B stays pending, A's own assignments are
+        completely untouched (no data loss).
+        """
+        db_path = tmp_path / "memory.db"
+        a_id = _seed_topic(db_path, "topic-a", doc_count=2, n_docs=2)
+        b_id = _seed_topic(db_path, "topic-b", doc_count=2, n_docs=2)
+        c_id = _seed_topic(
+            db_path, "topic-c", doc_count=1, n_docs=1, review_status="accepted",
+        )
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {
+                    a_id: {"action": "merge", "target_id": b_id, "reason": "dup"},
+                    b_id: {"action": "merge", "target_id": c_id, "reason": "dup"},
+                }
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj"], input="y\n",
+            )
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            a_topic = db.taxonomy.get_topic_by_id(a_id)
+            b_topic = db.taxonomy.get_topic_by_id(b_id)
+            c_topic = db.taxonomy.get_topic_by_id(c_id)
+            a_assignments = db.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?", (a_id,),
+            ).fetchone()[0]
+
+        # A stays pending, untouched — no merge was ever attempted against it.
+        assert a_topic is not None
+        assert a_topic["review_status"] == "pending"
+        assert a_assignments == 2
+        # B->C applied: B gone, C absorbed B's docs (1 own + 2 from B == 3).
+        assert b_topic is None
+        assert c_topic["doc_count"] == 3
+        assert (
+            "0 accepted, 0 renamed, 0 deleted, 1 merged, 1 skipped, 0 failed."
+            in result.output
+        )
+
+    def test_dry_run_mixed_batch_zero_mutations(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        t_accept = _seed_topic(db_path, "accept-me", doc_count=1)
+        t_rename = _seed_topic(db_path, "bad-label", doc_count=1)
+        t_delete = _seed_topic(db_path, "pytest fixture scaffolding", doc_count=1)
+        t_target = _seed_topic(
+            db_path, "keep-me", doc_count=1, review_status="accepted",
+        )
+        t_merge = _seed_topic(db_path, "dup-of-keep-me", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {
+                    t_accept: {"action": "accept"},
+                    t_rename: {"action": "rename", "label": "Good New Label"},
+                    t_delete: {"action": "delete", "reason": "pollution"},
+                    t_merge: {"action": "merge", "target_id": t_target, "reason": "dup"},
+                }
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj", "--dry-run"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Destructive" in result.output
+        with T2Database(db_path) as db:
+            for tid, expected_label in [
+                (t_accept, "accept-me"),
+                (t_rename, "bad-label"),
+                (t_delete, "pytest fixture scaffolding"),
+                (t_target, "keep-me"),
+                (t_merge, "dup-of-keep-me"),
+            ]:
+                topic = db.taxonomy.get_topic_by_id(tid)
+                assert topic is not None
+                assert topic["label"] == expected_label
+            assert db.taxonomy.get_topic_by_id(t_accept)["review_status"] == "pending"
+            assert db.taxonomy.get_topic_by_id(t_rename)["review_status"] == "pending"
+            assert db.taxonomy.get_topic_by_id(t_delete)["review_status"] == "pending"
+            assert db.taxonomy.get_topic_by_id(t_merge)["review_status"] == "pending"
+            assert db.taxonomy.get_topic_by_id(t_target)["review_status"] == "accepted"
+
+    def test_dispatch_raises_all_stay_pending_exit_zero(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        t1 = _seed_topic(db_path, "topic-1", doc_count=1)
+        t2 = _seed_topic(db_path, "topic-2", doc_count=1)
+        dispatch = AsyncMock(side_effect=RuntimeError("boom"))
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(taxonomy, ["review", "--auto", "--collection", "proj"])
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            assert db.taxonomy.get_topic_by_id(t1)["review_status"] == "pending"
+            assert db.taxonomy.get_topic_by_id(t2)["review_status"] == "pending"
+        assert "2 skipped" in result.output
+
+    def test_multi_batch_second_batch_dispatch_raises_first_batch_applies(
+        self, tmp_path: Path,
+    ) -> None:
+        """Finding 7: batch 1 succeeds, batch 2's dispatch call raises.
+
+        Batch-1 verdicts must still be applied; batch-2 topics stay
+        pending; exit code 0; exact skip count for batch 2's topics.
+        """
+        db_path = tmp_path / "memory.db"
+        # doc_count DESC ordering controls batch membership: t1,t2 (highest)
+        # land in batch 1; t3,t4 in batch 2, with --batch-size 2.
+        t1 = _seed_topic(db_path, "topic-1", doc_count=4)
+        t2 = _seed_topic(db_path, "topic-2", doc_count=3)
+        t3 = _seed_topic(db_path, "topic-3", doc_count=2)
+        t4 = _seed_topic(db_path, "topic-4", doc_count=1)
+
+        calls = {"n": 0}
+
+        async def _fake(prompt: str, schema: dict, **kw):  # noqa: ARG001
+            calls["n"] += 1
+            if calls["n"] == 1:
+                ids = [int(m) for m in re.findall(r"id=(\d+)", prompt)]
+                return {"verdicts": [{"id": tid, "action": "accept"} for tid in ids]}
+            raise RuntimeError("batch2 boom")
+
+        dispatch = AsyncMock(side_effect=_fake)
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy,
+                ["review", "--auto", "--collection", "proj", "--batch-size", "2"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert calls["n"] == 2
+        with T2Database(db_path) as db:
+            assert db.taxonomy.get_topic_by_id(t1)["review_status"] == "accepted"
+            assert db.taxonomy.get_topic_by_id(t2)["review_status"] == "accepted"
+            assert db.taxonomy.get_topic_by_id(t3)["review_status"] == "pending"
+            assert db.taxonomy.get_topic_by_id(t4)["review_status"] == "pending"
+        assert (
+            "2 accepted, 0 renamed, 0 deleted, 0 merged, 2 skipped, 0 failed." in result.output
+        )
+
+    def test_apply_loop_one_bad_delete_does_not_abort_remaining_actions(
+        self, tmp_path: Path,
+    ) -> None:
+        """Finding 2: t2_index_write raising for one delete must not abort
+
+        the remaining deletes/merges — it's counted as failed, the loop
+        continues, exit code stays 0.
+        """
+        db_path = tmp_path / "memory.db"
+        d1 = _seed_topic(db_path, "junk-1", doc_count=1, n_docs=1)
+        d2 = _seed_topic(db_path, "junk-2", doc_count=1, n_docs=1)
+        source_id = _seed_topic(db_path, "source", doc_count=1, n_docs=1)
+        target_id = _seed_topic(
+            db_path, "target", doc_count=1, n_docs=1, review_status="accepted",
+        )
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {
+                    d1: {"action": "delete", "reason": "pollution"},
+                    d2: {"action": "delete", "reason": "pollution"},
+                    source_id: {"action": "merge", "target_id": target_id, "reason": "dup"},
+                }
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router_delete_fails_for(db_path, d1)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj", "--yes"],
+            )
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            d1_topic = db.taxonomy.get_topic_by_id(d1)
+            d2_topic = db.taxonomy.get_topic_by_id(d2)
+            source_topic = db.taxonomy.get_topic_by_id(source_id)
+            target_topic = db.taxonomy.get_topic_by_id(target_id)
+        # d1's delete failed: topic untouched, still pending.
+        assert d1_topic is not None
+        assert d1_topic["review_status"] == "pending"
+        # d2's delete succeeded despite d1's failure.
+        assert d2_topic is None
+        # The merge (unrelated to the failing delete) still applied.
+        assert source_topic is None
+        assert target_topic["doc_count"] == 2
+        assert (
+            "0 accepted, 0 renamed, 1 deleted, 1 merged, 0 skipped, 1 failed." in result.output
+        )
+
+    def test_auto_no_limit_processes_all_20_via_5000_default(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        ids = [_seed_topic(db_path, f"topic-{i}", doc_count=1) for i in range(20)]
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id({tid: {"action": "accept"} for tid in ids})
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(taxonomy, ["review", "--auto", "--collection", "proj"])
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            accepted_count = db.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE review_status='accepted'"
+            ).fetchone()[0]
+        assert accepted_count == 20
+
+    def test_auto_limit_5_processes_exactly_5(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        ids = [_seed_topic(db_path, f"topic-{i}", doc_count=20 - i) for i in range(20)]
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id({tid: {"action": "accept"} for tid in ids})
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj", "--limit", "5"],
+            )
+
+        assert result.exit_code == 0, result.output
+        with T2Database(db_path) as db:
+            accepted_count = db.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE review_status='accepted'"
+            ).fetchone()[0]
+            pending_count = db.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE review_status='pending'"
+            ).fetchone()[0]
+        assert accepted_count == 5
+        assert pending_count == 15
+
+    def test_batch_size_2_dispatches_ceil_5_over_2(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        ids = [_seed_topic(db_path, f"topic-{i}", doc_count=1) for i in range(5)]
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id({tid: {"action": "accept"} for tid in ids})
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy,
+                ["review", "--auto", "--collection", "proj", "--batch-size", "2"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert dispatch.call_count == 3
+
+    def test_no_pending_topics_same_all_done_message(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        with T2Database(db_path):
+            pass
+
+        runner = CliRunner()
+        with patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path):
+            result = runner.invoke(taxonomy, ["review", "--auto", "--collection", "proj"])
+
+        assert result.exit_code == 0, result.output
+        assert (
+            "no unreviewed topics" in result.output.lower()
+            or "all done" in result.output.lower()
+        )
+
+    def test_mixed_outcome_summary_reports_exact_counts(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memory.db"
+        t_accept = _seed_topic(db_path, "accept-me", doc_count=1)
+        t_rename = _seed_topic(db_path, "bad-label", doc_count=1)
+        t_delete = _seed_topic(db_path, "pytest fixture scaffolding", doc_count=1)
+        t_target = _seed_topic(
+            db_path, "keep-me", doc_count=1, review_status="accepted",
+        )
+        t_merge = _seed_topic(db_path, "dup-of-keep-me", doc_count=1)
+        dispatch = AsyncMock(
+            side_effect=_dispatch_by_topic_id(
+                {
+                    t_accept: {"action": "accept"},
+                    t_rename: {"action": "rename", "label": "Good New Label"},
+                    t_delete: {"action": "delete", "reason": "pollution"},
+                    t_merge: {"action": "merge", "target_id": t_target, "reason": "dup"},
+                }
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+            patch.object(_mi, "t2_index_write", _t2_router(db_path)),
+            patch("nexus.operators.dispatch.claude_dispatch", dispatch),
+        ):
+            result = runner.invoke(
+                taxonomy, ["review", "--auto", "--collection", "proj"], input="y\n",
+            )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            "1 accepted, 1 renamed, 1 deleted, 1 merged, 0 skipped, 0 failed."
+            in result.output
+        )

--- a/tests/test_taxonomy_status_links.py
+++ b/tests/test_taxonomy_status_links.py
@@ -1,0 +1,69 @@
+"""Service-mode `nx taxonomy status` must report a real topic-link count.
+
+nexus-ntkr5: the service-mode branch hardcoded ``link_count = 0``
+("link count not exposed via public API") — stale since
+``get_topic_link_pairs`` became public; after the first
+``nx taxonomy links --refresh`` run the live store held 7,520 links while
+status still displayed "0 topic links". The service-mode branch is
+exercised here by forcing ``_has_raw_access`` False against a real SQLite
+T2 — both stores implement the same public taxonomy contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from nexus.db.t2 import T2Database
+
+
+def _seed(db_path: Path) -> None:
+    with T2Database(db_path) as db:
+        ids = []
+        for label in ("t1", "t2", "t3"):
+            cur = db.taxonomy.conn.execute(
+                "INSERT INTO topics (label, collection, doc_count, created_at) "
+                "VALUES (?, 'docs__alpha', 1, '2026-01-01T00:00:00Z')",
+                (label,),
+            )
+            ids.append(cur.lastrowid)
+        db.taxonomy.conn.commit()
+        db.taxonomy.upsert_topic_links(
+            [
+                {"from_topic_id": ids[0], "to_topic_id": ids[1], "link_count": 1, "link_types": ["cites"]},
+                {"from_topic_id": ids[1], "to_topic_id": ids[2], "link_count": 2, "link_types": ["relates"]},
+            ]
+        )
+
+
+def test_status_counts_links_via_public_api_in_service_mode(tmp_path: Path) -> None:
+    from nexus.commands.taxonomy_cmd import taxonomy
+
+    db_path = tmp_path / "memory.db"
+    _seed(db_path)
+
+    runner = CliRunner()
+    with (
+        patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path),
+        patch("nexus.commands.taxonomy_cmd._has_raw_access", return_value=False),
+    ):
+        result = runner.invoke(taxonomy, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "2 topic links" in result.output
+
+
+def test_status_raw_access_link_count_unchanged(tmp_path: Path) -> None:
+    from nexus.commands.taxonomy_cmd import taxonomy
+
+    db_path = tmp_path / "memory.db"
+    _seed(db_path)
+
+    runner = CliRunner()
+    with patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path):
+        result = runner.invoke(taxonomy, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "2 topic links" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "6.9.0"
+version = "6.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Promotes develop to main and bumps all release manifests to 6.10.0. Ships with (and requires) engine-service-v0.1.43.

## Highlights
- **`nx taxonomy review --auto`** — batched unattended topic curation (claude_dispatch verdicts, confirm-gated destructive plan, merge-chain guards, fault-tolerant apply). Productizes the validated 524-topic manual pass.
- **Catalog bibliographic metadata surfacing** — `nx enrich bib` now writes the catalog Document rows' bib_* columns (previously writer-less since RDR-101); all browsing-surface readers carry them on both backends; event-sourced write path (default-ON) persists + carry-forwards them; new `--backfill-catalog` flag (idempotent, zero API calls).
- **GH #1402 fixes** — engine boot crash-loop on the superuser-owned diag view (owner-restricted grants, shipped in engine-service-v0.1.43, floor bumped to 0.1.43); chash-probe fallback log no longer asserts a wrong cause. Closes #1402.
- **Taxonomy integrity** — topic_links cleared at every SQLite topic-deletion site (~6.9k orphans class); service-mode status reports the real link count (7,518 were invisible).
- **MinerU upgrade behavior documented** (cycle-if-running, on-demand spawn, `nx mineru start` pre-warm).

## Gates run
- Full unit suite: 13,245 passed / 0 failed
- `tests/e2e/local-service-gate.sh`: LOCAL-SERVICE GATE PASSED (475 passed, vacuity guard ok)
- `release-sandbox.sh smoke`: [done]
- `upgrade-shakeout.sh run`: 12/12 PASS
- `scripts/check_engine_release_floor.py`: exit 0 (cloud on v0.1.43, floor v0.1.43)
- Engine v0.1.43: deployed + cloud-gated green + record-deploy verified against live /version
- Parity tests (marketplace/mcpb/engine-pin): 18/18